### PR TITLE
feat: support sending mms without media

### DIFF
--- a/libs/gql-schema/organization-settings.ts
+++ b/libs/gql-schema/organization-settings.ts
@@ -13,6 +13,7 @@ export const schema = `
     showDoNotAssignMessage: Boolean
     doNotAssignMessage: String
     defaultAutosendingControlsMode: AutosendingControlsMode
+    maxSmsSegmentLength: Int
 
     # Superadmin
     startCampaignRequiresApproval: Boolean
@@ -28,6 +29,7 @@ export const schema = `
     confirmationClickForScriptLinks: Boolean!
     showDoNotAssignMessage: Boolean!
     doNotAssignMessage: String!
+    maxSmsSegmentLength: Int
 
     # Supervolunteer
     startCampaignRequiresApproval: Boolean

--- a/libs/spoke-codegen/src/graphql/general-settings.graphql
+++ b/libs/spoke-codegen/src/graphql/general-settings.graphql
@@ -76,3 +76,26 @@ mutation UpdateAutosendingSettings(
     defaultAutosendingControlsMode
   }
 }
+
+query GetMessageSendingSettings($organizationId: String!) {
+  organization(id: $organizationId) {
+    id
+    settings {
+      id
+      maxSmsSegmentLength
+    }
+  }
+}
+
+mutation UpdateMessageSendingSettings(
+  $organizationId: String!
+  $maxSmsSegmentLength: Int
+) {
+  editOrganizationSettings(
+    id: $organizationId
+    input: { maxSmsSegmentLength: $maxSmsSegmentLength }
+  ) {
+    id
+    maxSmsSegmentLength
+  }
+}

--- a/libs/spoke-codegen/src/graphql/spoke-context.graphql
+++ b/libs/spoke-codegen/src/graphql/spoke-context.graphql
@@ -20,4 +20,5 @@ fragment OrganizationSettingsInfo on OrganizationSettings {
   scriptPreviewForSupervolunteers
   defaultCampaignBuilderMode
   defaultAutosendingControlsMode
+  maxSmsSegmentLength
 }

--- a/src/components/MessageLengthInfo.tsx
+++ b/src/components/MessageLengthInfo.tsx
@@ -1,14 +1,13 @@
-import { getCharCount } from "@trt2/gsm-charset-utils";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { replaceEasyGsmWins } from "../lib/charset-utils";
+import { getSpokeCharCount } from "../lib/charset-utils";
 
 const MessageLengthInfo: React.SFC<{ messageText: string }> = ({
   messageText
 }) => {
-  const { charCount, msgCount, charsPerSegment } = getCharCount(
-    replaceEasyGsmWins(messageText)
+  const { charCount, msgCount, charsPerSegment } = getSpokeCharCount(
+    messageText
   );
   const segmentInfo = msgCount === 1 ? "(1 segment)" : `(${msgCount} segments)`;
 

--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -2,7 +2,6 @@ import { withApollo } from "@apollo/client/react/hoc";
 import { blue, green, grey, orange, red } from "@material-ui/core/colors";
 import type { CampaignVariable } from "@spoke/spoke-codegen";
 import { IsValidAttachmentDocument } from "@spoke/spoke-codegen";
-import { getCharCount } from "@trt2/gsm-charset-utils";
 import type { ContentBlock } from "draft-js";
 import {
   CompositeDecorator,
@@ -14,7 +13,7 @@ import {
 import escapeRegExp from "lodash/escapeRegExp";
 import React from "react";
 
-import { replaceEasyGsmWins } from "../lib/charset-utils";
+import { getSpokeCharCount, replaceEasyGsmWins } from "../lib/charset-utils";
 import { delimit, getAttachmentLink, getMessageType } from "../lib/scripts";
 import baseTheme from "../styles/theme";
 import Chip from "./Chip";
@@ -369,7 +368,7 @@ class ScriptEditor extends React.Component<Props, State> {
 
   render() {
     const text = this.state.editorState.getCurrentContent().getPlainText();
-    const info = getCharCount(replaceEasyGsmWins(text));
+    const info = getSpokeCharCount(text);
     const messageType = getMessageType(text);
 
     return (

--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -121,6 +121,7 @@ interface Props {
   scriptFields: string[];
   campaignVariables: CampaignVariable[];
   integrationSourced: boolean;
+  maxSmsSegmentLength: number | null;
   onChange: (value: string) => Promise<void> | void;
   receiveFocus?: boolean;
 }
@@ -318,7 +319,7 @@ class ScriptEditor extends React.Component<Props, State> {
 
   renderAttachmentWarning() {
     const text = this.state.editorState.getCurrentContent().getPlainText();
-    const messageType = getMessageType(text);
+    const messageType = getMessageType(text, this.props.maxSmsSegmentLength);
     if (messageType === "MMS" && !this.state.validAttachment) {
       return (
         <div style={{ color: baseTheme.colors.red }}>
@@ -369,7 +370,7 @@ class ScriptEditor extends React.Component<Props, State> {
   render() {
     const text = this.state.editorState.getCurrentContent().getPlainText();
     const info = getSpokeCharCount(text);
-    const messageType = getMessageType(text);
+    const messageType = getMessageType(text, this.props.maxSmsSegmentLength);
 
     return (
       <div>

--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -116,6 +116,7 @@ class GSScriptField extends GSFormField {
             scriptFields={scriptFields}
             campaignVariables={campaignVariables}
             integrationSourced={integrationSourced}
+            maxSmsSegmentLength={orgSettings.maxSmsSegmentLength}
             expandable
             onChange={(val) => this.setState({ script: val })}
           />

--- a/src/components/forms/GSScriptOptionsField.jsx
+++ b/src/components/forms/GSScriptOptionsField.jsx
@@ -188,6 +188,7 @@ class GSScriptOptionsField extends GSFormField {
             scriptFields={scriptFields}
             campaignVariables={campaignVariables}
             integrationSourced={integrationSourced}
+            maxSmsSegmentLength={orgSettings.maxSmsSegmentLength}
             receiveFocus
             expandable
             onChange={(val) => this.setState({ scriptDraft: val.trim() })}

--- a/src/containers/Settings/components/General.jsx
+++ b/src/containers/Settings/components/General.jsx
@@ -25,6 +25,7 @@ import { loadData } from "../../hoc/with-operations";
 import AutosendingSettingsCard from "./AutosendingSettingsCard";
 import CampaignBuilderSettingsCard from "./CampaignBuilderSettingsCard";
 import EditName from "./EditName";
+import MessageSendingSettingsCard from "./MessageSendingSettingsCard";
 import RejectedTextersMessageCard from "./RejectedTextersMessageCard";
 import Review10DlcInfo from "./Review10DlcInfo";
 import ScriptPreviewSettingsCard from "./ScriptPreviewSettingsCard";
@@ -469,6 +470,11 @@ class Settings extends React.Component {
         />
 
         <AutosendingSettingsCard
+          organizationId={organization.id}
+          style={{ marginBottom: 20 }}
+        />
+
+        <MessageSendingSettingsCard
           organizationId={organization.id}
           style={{ marginBottom: 20 }}
         />

--- a/src/containers/Settings/components/MessageSendingSettingsCard.tsx
+++ b/src/containers/Settings/components/MessageSendingSettingsCard.tsx
@@ -1,0 +1,117 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardHeader from "@material-ui/core/CardHeader";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Switch from "@material-ui/core/Switch";
+import TextField from "@material-ui/core/TextField";
+import Alert from "@material-ui/lab/Alert";
+import {
+  useGetMessageSendingSettingsQuery,
+  useUpdateMessageSendingSettingsMutation
+} from "@spoke/spoke-codegen";
+import React from "react";
+
+export interface MessageSendingSettingsCardProps {
+  organizationId: string;
+  style?: React.CSSProperties;
+}
+
+// eslint-disable-next-line max-len
+export const MessageSendingSettingsCard: React.FC<MessageSendingSettingsCardProps> = (
+  props
+) => {
+  const { organizationId, style } = props;
+
+  const getSettingsState = useGetMessageSendingSettingsQuery({
+    variables: { organizationId }
+  });
+  const settings = getSettingsState?.data?.organization?.settings;
+
+  const [
+    setMaxSmsSegmentLength,
+    updateState
+  ] = useUpdateMessageSendingSettingsMutation();
+
+  const working = getSettingsState.loading || updateState.loading;
+  const errorMsg =
+    getSettingsState.error?.message ?? updateState.error?.message;
+
+  const maxSmsSegmentLength = settings?.maxSmsSegmentLength;
+  const showMaxSmsSegmentLength = maxSmsSegmentLength !== null;
+
+  const setNewMaxSmsSegmentLength = async (
+    newMax: number | null | undefined
+  ) => {
+    await setMaxSmsSegmentLength({
+      variables: {
+        organizationId,
+        maxSmsSegmentLength: newMax
+      }
+    });
+  };
+
+  // eslint-disable-next-line max-len
+  const handleChangeMaxSmsSegmentLength: React.ChangeEventHandler<HTMLInputElement> = async (
+    event
+  ) => {
+    if (working) return;
+    const newMax = event.target.valueAsNumber;
+    await setNewMaxSmsSegmentLength(newMax);
+  };
+
+  // eslint-disable-next-line max-len
+  const handleToggleMmsConversion: React.ChangeEventHandler<HTMLInputElement> = async (
+    event
+  ) => {
+    const { checked } = event.target;
+    const DEFAULT_MAX_SMS_SEGMENT_LENGTH = 3;
+    const newMax = checked ? DEFAULT_MAX_SMS_SEGMENT_LENGTH : null;
+    await setNewMaxSmsSegmentLength(newMax);
+  };
+
+  return (
+    <Card style={style}>
+      <CardHeader title="Message Sending Settings" disableTypography />
+      <CardContent>
+        {errorMsg && <Alert severity="error">Error: {errorMsg}</Alert>}
+        <p>
+          Turn on this feature to automatically convert long SMS messages to
+          MMS. If turned on, SMS messages <i>longer</i> than the length you set
+          will be converted. For example, if you set the max length to 3, a 4
+          segment SMS message will be converted to MMS.
+        </p>
+        <p style={{ marginBottom: 25 }}>
+          Messages longer than 3 segments are usually cheaper to send as MMS.
+          You may notice changes in deliverability when switching from SMS to
+          MMS messages.{" "}
+          <a
+            href="https://docs.spokerewired.com/article/86-include-an-image-in-a-message"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more about sending MMS here
+          </a>
+        </p>
+        <FormControlLabel
+          label="Convert long SMS messages to MMS?"
+          control={
+            <Switch
+              checked={showMaxSmsSegmentLength}
+              onChange={handleToggleMmsConversion}
+            />
+          }
+        />
+        {showMaxSmsSegmentLength && (
+          <TextField
+            label="Max SMS Segment Length"
+            type="number"
+            value={settings?.maxSmsSegmentLength}
+            onChange={handleChangeMaxSmsSegmentLength}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default MessageSendingSettingsCard;

--- a/src/lib/charset-utils.ts
+++ b/src/lib/charset-utils.ts
@@ -1,3 +1,5 @@
+import { getCharCount } from "@trt2/gsm-charset-utils";
+
 const gsmReplacements = [
   ["‘", "'"],
   ["’", "'"],
@@ -12,6 +14,9 @@ export const replaceEasyGsmWins = (text: string) =>
     (acc, replacement) => acc.replace(replacement[0], replacement[1]),
     text
   );
+
+export const getSpokeCharCount = (text: string) =>
+  getCharCount(replaceEasyGsmWins(text));
 
 export const replaceCurlyApostrophes = (rawText: string) =>
   rawText.replace(/[\u2018\u2019]/g, "'");

--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -6,6 +6,8 @@ import type {
 import escapeRegExp from "lodash/escapeRegExp";
 import isNil from "lodash/isNil";
 
+import { getSpokeCharCount } from "./charset-utils";
+
 export const delimiters = {
   startDelimiter: "{",
   endDelimiter: "}"
@@ -38,7 +40,7 @@ const TITLE_CASE_FIELDS = [
   "texterLastName"
 ];
 
-const mediaExtractor = /\[\s*(http[^\]\s]*)\s*\]/;
+export const mediaExtractor = /\[\s*(http[^\]\s]*)\s*\]/;
 
 // Special first names that should not be capitalized
 const LOWERCASE_FIRST_NAMES = ["friend", "there"];
@@ -132,8 +134,17 @@ export const getAttachmentLink = (text: string) => {
   return null;
 };
 
-export const getMessageType = (text: string) => {
-  return mediaExtractor.test(text) ? "MMS" : "SMS";
+export const getMessageType = (
+  text: string,
+  maxSmsSegmentLength: number | null
+) => {
+  const { msgCount } = getSpokeCharCount(text);
+  if (
+    mediaExtractor.test(text) ||
+    (maxSmsSegmentLength && msgCount > maxSmsSegmentLength)
+  )
+    return "MMS";
+  return "SMS";
 };
 
 export enum ScriptTokenType {

--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -1,9 +1,10 @@
-import type { CampaignVariable } from "@spoke/spoke-codegen";
+import type {
+  CampaignContact,
+  CampaignVariable,
+  User
+} from "@spoke/spoke-codegen";
 import escapeRegExp from "lodash/escapeRegExp";
 import isNil from "lodash/isNil";
-
-import type { CampaignContact } from "../api/campaign-contact";
-import type { User } from "../api/user";
 
 export const delimiters = {
   startDelimiter: "{",

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -482,6 +482,7 @@ input OrganizationSettingsInput {
   showDoNotAssignMessage: Boolean
   doNotAssignMessage: String
   defaultAutosendingControlsMode: AutosendingControlsMode
+  maxSmsSegmentLength: Int
 
   # Superadmin
   startCampaignRequiresApproval: Boolean
@@ -497,6 +498,7 @@ type OrganizationSettings {
   confirmationClickForScriptLinks: Boolean!
   showDoNotAssignMessage: Boolean!
   doNotAssignMessage: String!
+  maxSmsSegmentLength: Int
 
   # Supervolunteer
   startCampaignRequiresApproval: Boolean

--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -204,8 +204,6 @@ export const sendMessage = async (
     contactZipCode: contactZipCode === "" ? null : contactZipCode
   };
 
-  console.log(messageInput);
-
   try {
     const result = await numbers.sms.sendMessage(messageInput);
     const { data, errors } = result;

--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -1,3 +1,6 @@
+import type { Knex } from "knex";
+import type { PoolClient } from "pg";
+
 import { config } from "../../../config";
 import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import { stringIsAValidUrl } from "../../../lib/utils";

--- a/src/server/api/organization-settings.ts
+++ b/src/server/api/organization-settings.ts
@@ -28,6 +28,7 @@ interface IOrganizationSettings {
   doNotAssignMessage: string;
   defaultCampaignBuilderMode: CampaignBuilderMode;
   defaultAutosendingControlsMode: AutosendingControlsMode;
+  maxSmsSegmentLength: number | null;
 }
 
 const SETTINGS_PERMISSIONS: {
@@ -45,7 +46,8 @@ const SETTINGS_PERMISSIONS: {
   defaultAutosendingControlsMode: UserRoleType.ADMIN,
   defaulTexterApprovalStatus: UserRoleType.OWNER,
   numbersApiKey: UserRoleType.OWNER,
-  trollbotWebhookUrl: UserRoleType.OWNER
+  trollbotWebhookUrl: UserRoleType.OWNER,
+  maxSmsSegmentLength: UserRoleType.TEXTER
 };
 
 const SETTINGS_WRITE_PERMISSIONS: {
@@ -63,7 +65,8 @@ const SETTINGS_WRITE_PERMISSIONS: {
   showDoNotAssignMessage: UserRoleType.OWNER,
   doNotAssignMessage: UserRoleType.OWNER,
   defaultAutosendingControlsMode: UserRoleType.OWNER,
-  startCampaignRequiresApproval: UserRoleType.SUPERADMIN
+  startCampaignRequiresApproval: UserRoleType.SUPERADMIN,
+  maxSmsSegmentLength: UserRoleType.OWNER
 };
 
 const SETTINGS_NAMES: Partial<
@@ -86,7 +89,8 @@ const SETTINGS_DEFAULTS: IOrganizationSettings = {
   doNotAssignMessage:
     "Your ability to request texts has been put on hold. Please a contact a text team leader for more information.",
   defaultCampaignBuilderMode: CampaignBuilderMode.Advanced,
-  defaultAutosendingControlsMode: AutosendingControlsMode.Detailed
+  defaultAutosendingControlsMode: AutosendingControlsMode.Detailed,
+  maxSmsSegmentLength: 3
 };
 
 const SETTINGS_TRANSFORMERS: Partial<
@@ -133,13 +137,17 @@ export const getOrgFeature = <T extends keyof IOrganizationSettings>(
   const finalName = SETTINGS_NAMES[featureName] ?? featureName;
   try {
     const features = JSON.parse(rawFeatures);
-    const value = features[finalName] ?? defaultValue ?? null;
+
+    const foundValue = features[finalName];
+    const returnValue =
+      foundValue === undefined ? defaultValue ?? null : foundValue;
+
     const transformer = SETTINGS_TRANSFORMERS[featureName];
-    if (transformer && value) {
-      const result = transformer(value);
+    if (transformer && returnValue) {
+      const result = transformer(returnValue);
       return result as IOrganizationSettings[T];
     }
-    return value;
+    return returnValue;
   } catch (_err) {
     return SETTINGS_DEFAULTS[featureName] ?? null;
   }
@@ -183,7 +191,8 @@ export const resolvers = {
       "defaultCampaignBuilderMode",
       "showDoNotAssignMessage",
       "doNotAssignMessage",
-      "defaultAutosendingControlsMode"
+      "defaultAutosendingControlsMode",
+      "maxSmsSegmentLength"
     ])
   }
 };

--- a/src/server/organization-settings.spec.ts
+++ b/src/server/organization-settings.spec.ts
@@ -37,7 +37,8 @@ describe("get organization settings", () => {
     defaultAutosendingControlsMode: AutosendingControlsMode.Basic,
     defaulTexterApprovalStatus: RequestAutoApproveType.APPROVAL_REQUIRED,
     numbersApiKey: "SomethingSecret",
-    trollbotWebhookUrl: "https://rewired.coop/trolls"
+    trollbotWebhookUrl: "https://rewired.coop/trolls",
+    maxSmsSegmentLength: 3
   };
 
   const makeSettingsRequest = async (
@@ -68,6 +69,7 @@ describe("get organization settings", () => {
                 defaulTexterApprovalStatus
                 numbersApiKey
                 trollbotWebhookUrl
+                maxSmsSegmentLength
               }
             }
           }
@@ -135,6 +137,7 @@ describe("get organization settings", () => {
     );
     expect(settings.numbersApiKey).not.toBeNull();
     expect(settings.trollbotWebhookUrl).toEqual(features.trollbotWebhookUrl);
+    expect(settings.maxSmsSegmentLength).toEqual(features.maxSmsSegmentLength);
   });
 
   it("returns the correct role required", () => {


### PR DESCRIPTION
## Description

This adds an organization setting to support the automatic conversion of long SMS messages to MMS.

## Motivation and Context

Closes #1 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

![image](https://github.com/With-the-Ranks/Spoke/assets/76596635/2665e1ff-1a6a-4c67-ab45-1ccd91df7d8b)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
