### PR TITLE
fix(mms): get feature for max sms segment length

### DIFF
--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -10,6 +10,7 @@ import { makeNumbersClient } from "../../lib/assemble-numbers";
 import { r } from "../../models";
 import statsd from "../../statsd";
 import { errToObj } from "../../utils";
+import { getOrgFeature } from "../organization-settings";
 import type { MessagingServiceRecord, RequestHandlerFactory } from "../types";
 import { MessagingServiceType } from "../types";
 import { symmetricDecrypt } from "./crypto";
@@ -179,13 +180,13 @@ export const sendMessage = async (
     .where({ id: campaignContactId })
     .first("zip");
 
-  const { maxSmsSegmentLength } = await r
+  const { features } = await r
     .reader("organization")
     .where({ id: organizationId })
     .first("features")
-    .then(({ features }) => JSON.parse(features))
     .catch(() => ({}));
 
+  const maxSmsSegmentLength = getOrgFeature("maxSmsSegmentLength", features);
   const { body, mediaUrl } = messageComponents(messageText);
 
   const mediaUrls = mediaUrl


### PR DESCRIPTION
## Description

This fetches the default for the  org feature `maxSmsSegmentLength` correctly when the feature is not set explicitly

## Motivation and Context

Fix for #2 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
