### PR TITLE
fix(column mapping): remove create as from custom field value

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ConfigureColumnMappingDialog.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ConfigureColumnMappingDialog.tsx
@@ -228,7 +228,11 @@ const ConfigureColumnMappingDialog: React.FC<ConfigureColumnMappingDialogProps> 
                         <Autocomplete
                           value={value}
                           onChange={(_event, newValue) => {
-                            onChange(newValue);
+                            const quotedValue = newValue?.match(
+                              /"([^"]+)"/
+                            )?.[1];
+                            const valueToSet = quotedValue ?? newValue;
+                            onChange(valueToSet);
                           }}
                           selectOnFocus
                           clearOnBlur

--- a/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ConfigureColumnMappingDialog.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignContactsForm/components/ConfigureColumnMappingDialog.tsx
@@ -228,10 +228,10 @@ const ConfigureColumnMappingDialog: React.FC<ConfigureColumnMappingDialogProps> 
                         <Autocomplete
                           value={value}
                           onChange={(_event, newValue) => {
-                            const quotedValue = newValue?.match(
+                            const quotedWord = newValue?.match(
                               /"([^"]+)"/
                             )?.[1];
-                            const valueToSet = quotedValue ?? newValue;
+                            const valueToSet = quotedWord ?? newValue;
                             onChange(valueToSet);
                           }}
                           selectOnFocus


### PR DESCRIPTION
## Description

This fixes an issue where mapped columns would be created as 'Create as "value"' instead of the value

## Motivation and Context

We encountered this issue during a demo

## How Has This Been Tested?

This has been tested locally 
## Screenshots (if appropriate):

![image](https://github.com/With-the-Ranks/Spoke/assets/76596635/8eaac0cd-ce89-417c-8cc4-bab7b24c6549)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
