### PR TITLE
chore: remove bernie sms references

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -164,14 +164,6 @@ const validators = {
     dec: "Disable use of has unassigned contacts variable",
     default: false
   }),
-  BAD_WORD_TOKEN: str({
-    desc: "Bearer token used for authorization with BAD_WORD_URL.",
-    default: undefined
-  }),
-  BAD_WORD_URL: url({
-    desc: "URL to notify with message text whenever a message is sent.",
-    default: undefined
-  }),
   BASE_URL: url({
     desc:
       "The base URL of the website, without trailing slash, used to construct various URLs.",

--- a/src/server/api/lib/send-message.ts
+++ b/src/server/api/lib/send-message.ts
@@ -7,7 +7,6 @@ import {
   ContactOptedOutError,
   OutsideTextingHoursError
 } from "src/server/send-message-errors";
-import request from "superagent";
 
 import { UserRoleType } from "../../../api/organization-membership";
 import { config } from "../../../config";
@@ -16,7 +15,6 @@ import { DateTime } from "../../../lib/datetime";
 import { hasRole } from "../../../lib/permissions";
 import { isNowBetween } from "../../../lib/timezones";
 import { getSendBeforeUtc } from "../../../lib/tz-helpers";
-import logger from "../../../logger";
 import { eventBus, EventType } from "../../event-bus";
 import { r } from "../../models";
 import type { UserRecord } from "../types";
@@ -334,21 +332,6 @@ export const sendMessage = async (
   // Send message after we are sure messageInstance has been persisted
   const service = serviceMap[service_type];
   service.sendMessage(toInsert, record.organization_id);
-
-  // Send message to BernieSMS to be checked for bad words
-  const badWordUrl = config.BAD_WORD_URL;
-  if (badWordUrl) {
-    request
-      .post(badWordUrl)
-      .timeout(5000)
-      .set("Authorization", `Token ${config.BAD_WORD_TOKEN}`)
-      .send({ user_id: user.auth0_id, message: toInsert.text })
-      .end((err, _res) => {
-        if (err) {
-          logger.error("Error submitting message to bad word service: ", err);
-        }
-      });
-  }
 
   return contactUpdateResult;
 };


### PR DESCRIPTION
## Description

This removes references to Bernie SMS 🥲 

## Motivation and Context

Trollbot is built into Spoke, and we should prefer building our own sweeping system into Spoke if the Bernie SMS feature set is useful for users

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
