### PR TITLE
chore(user menu): rename teams to organizations

### DIFF
--- a/src/containers/UserMenu/index.tsx
+++ b/src/containers/UserMenu/index.tsx
@@ -120,7 +120,7 @@ const UserMenu: React.FC<Props> = (props) => {
           </MenuItem>
         )}
         <Divider />
-        <ListSubheader>Teams</ListSubheader>
+        <ListSubheader>Organizations</ListSubheader>
         {currentUser?.organizations?.map((organization) => (
           <OrganizationItem
             key={organization!.id}


### PR DESCRIPTION
## Description

This renames "teams" to organizations in the user menu

## Motivation and Context

Organization specific teams are a thing in our fork of Spoke, so the use of the word "Teams" here is confusing

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

![image](https://github.com/With-the-Ranks/Spoke/assets/76596635/d8e9f0d1-6ae5-4db9-bcf4-30e686b86a00)

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
