### PR TITLE
refactor(campaign): simplify subtypes

### DIFF
--- a/libs/gql-schema/campaign-contact-tag.ts
+++ b/libs/gql-schema/campaign-contact-tag.ts
@@ -3,8 +3,6 @@ export const schema = `
     id: String!
     tag: Tag!
     tagger: User!
-    createdAt: String!
-    updatedAt: String!
   }
 `;
 

--- a/libs/gql-schema/campaign-variable.ts
+++ b/libs/gql-schema/campaign-variable.ts
@@ -10,18 +10,6 @@ export const schema = `
     displayOrder: Int!
     name: String!
     value: String
-    createdAt: String!
-    updatedAt: String!
-  }
-
-  type CampaignVariableEdge {
-    cursor: Cursor!
-    node: CampaignVariable!
-  }
-
-  type CampaignVariablePage {
-    edges: [CampaignVariableEdge!]!
-    pageInfo: RelayPageInfo!
   }
 `;
 

--- a/libs/gql-schema/campaign.ts
+++ b/libs/gql-schema/campaign.ts
@@ -106,7 +106,7 @@ export const schema = `
     editors: String
     teams: [Team!]!
     campaignGroups: CampaignGroupPage
-    campaignVariables: CampaignVariablePage!
+    campaignVariables: [CampaignVariable!]!
     textingHoursStart: Int
     textingHoursEnd: Int
     isAutoassignEnabled: Boolean!
@@ -177,7 +177,7 @@ export const schema = `
     introHtml: String
     externalSystemId: String
     useDynamicAssignment: Boolean
-    contacts: [CampaignContactInput]
+    contacts: [CampaignContactInput!]
     contactsFile: Upload
     externalListId: String
     filterOutLandlines: Boolean
@@ -190,7 +190,7 @@ export const schema = `
     campaignVariables: [CampaignVariableInput!]
     texters: TexterInput
     interactionSteps: InteractionStepInput
-    cannedResponses: [CannedResponseInput]
+    cannedResponses: [CannedResponseInput!]
     textingHoursStart: Int
     textingHoursEnd: Int
     isAutoassignEnabled: Boolean

--- a/libs/spoke-codegen/src/graphql/campaign-variables.graphql
+++ b/libs/spoke-codegen/src/graphql/campaign-variables.graphql
@@ -10,29 +10,23 @@ query GetCampaignVariables($campaignId: String!) {
     id
     isTemplate
     campaignVariables {
-      edges {
-        node {
-          ...CampaignVariableInfo
-        }
-      }
+      ...CampaignVariableInfo
     }
   }
 }
+
 
 query GetAssignmentCampaignVariables($assignmentId: String!) {
   assignment(id: $assignmentId) {
     campaign {
       id
       campaignVariables {
-        edges {
-          node {
-            ...CampaignVariableInfo
-          }
-        }
+        ...CampaignVariableInfo
       }
     }
   }
 }
+
 
 mutation EditCampaignVariables(
   $campaignId: String!
@@ -44,11 +38,7 @@ mutation EditCampaignVariables(
   ) {
     id
     campaignVariables {
-      edges {
-        node {
-          ...CampaignVariableInfo
-        }
-      }
+      ...CampaignVariableInfo
     }
     isStarted
     isApproved

--- a/src/api/campaign-variable.ts
+++ b/src/api/campaign-variable.ts
@@ -1,0 +1,12 @@
+/* eslint-disable import/prefer-default-export */
+import type { CampaignVariable } from "@spoke/spoke-codegen";
+
+export const sortCampaignVariables = (
+  campaignVariables: CampaignVariable[]
+) => {
+  return campaignVariables.sort((cv1, cv2) => {
+    if (cv1.displayOrder < cv2.displayOrder) return -1;
+    if (cv1.displayOrder > cv2.displayOrder) return 1;
+    return 0;
+  });
+};

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseEditor.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseEditor.tsx
@@ -1,11 +1,10 @@
 import Button from "@material-ui/core/Button";
+import type { CampaignVariable, CannedResponse } from "@spoke/spoke-codegen";
 import { css, StyleSheet } from "aphrodite";
 import React from "react";
 import Form from "react-formal";
 import * as yup from "yup";
 
-import type { CampaignVariable } from "../../../../../api/campaign-variable";
-import type { CannedResponse } from "../../../../../api/canned-response";
 import GSForm from "../../../../../components/forms/GSForm";
 import SpokeFormField from "../../../../../components/forms/SpokeFormField";
 import { dataTest } from "../../../../../lib/attributes";
@@ -49,7 +48,7 @@ const CannedResponseEditor: React.SFC<CannedResponseEditorProps> = (props) => {
   return (
     <GSForm schema={modelSchema} onSubmit={handleSave}>
       <SpokeFormField
-        {...dataTest("title")}
+        {...dataTest("title", false)}
         name="title"
         context="responseEditor"
         fullWidth
@@ -57,7 +56,7 @@ const CannedResponseEditor: React.SFC<CannedResponseEditorProps> = (props) => {
         value={editingResponse?.title}
       />
       <SpokeFormField
-        {...dataTest("editorResponse")}
+        {...dataTest("editorResponse", false)}
         customFields={customFields}
         campaignVariables={campaignVariables}
         integrationSourced={integrationSourced}
@@ -71,7 +70,7 @@ const CannedResponseEditor: React.SFC<CannedResponseEditorProps> = (props) => {
       />
       <div className={css(styles.buttonRow)}>
         <Form.Submit
-          {...dataTest("addResponse")}
+          {...dataTest("addResponse", false)}
           type="submit"
           label={submitLabel}
           style={{

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseRow.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/components/CannedResponseRow.tsx
@@ -12,7 +12,7 @@ import { scriptToTokens } from "../../../../../lib/scripts";
 interface Props {
   cannedResponse: CannedResponse;
   customFields: string[];
-  campaignVariables: Omit<CampaignVariable, "createdAt" | "updatedAt">[];
+  campaignVariables: CampaignVariable[];
   onDelete(): void;
   onToggleResponseEditor(): void;
 }
@@ -46,7 +46,7 @@ export const CannedResponseRow: React.FC<Props> = ({
 
   return (
     <LargeListItem
-      {...dataTest("cannedResponse")}
+      {...dataTest("cannedResponse", false)}
       draggable
       key={cannedResponse.id}
       primaryText={cannedResponse.title}

--- a/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignCannedResponsesForm/index.tsx
@@ -2,10 +2,7 @@ import type { ApolloQueryResult } from "@apollo/client";
 import { gql } from "@apollo/client";
 import Button from "@material-ui/core/Button";
 import CreateIcon from "@material-ui/icons/Create";
-import type {
-  CampaignVariablePage,
-  CannedResponse
-} from "@spoke/spoke-codegen";
+import type { CampaignVariable, CannedResponse } from "@spoke/spoke-codegen";
 import isEqual from "lodash/isEqual";
 import unionBy from "lodash/unionBy";
 import uniqBy from "lodash/uniqBy";
@@ -40,7 +37,7 @@ interface HocProps {
     campaign: {
       id: string;
       cannedResponses: CannedResponse[];
-      campaignVariables: CampaignVariablePage;
+      campaignVariables: CampaignVariable[];
       isStarted: boolean;
       customFields: string[];
       externalSystem: { id: string } | null;
@@ -344,14 +341,9 @@ class CampaignCannedResponsesForm extends React.Component<InnerProps, State> {
   scriptVariables = () => {
     const {
       data: {
-        campaign: {
-          customFields,
-          campaignVariables: { edges: campaignVariableEdges }
-        }
+        campaign: { customFields, campaignVariables }
       }
     } = this.props;
-
-    const campaignVariables = campaignVariableEdges.map(({ node }) => node);
 
     return { customFields, campaignVariables };
   };
@@ -510,13 +502,9 @@ const queries: QueryMap<InnerProps> = {
           isApproved
           customFields
           campaignVariables {
-            edges {
-              node {
-                id
-                name
-                value
-              }
-            }
+            id
+            name
+            value
           }
           externalSystem {
             id

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/index.tsx
@@ -6,18 +6,16 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import Grid from "@material-ui/core/Grid";
-import type { CampaignVariablePage } from "@spoke/spoke-codegen";
+import type { Action, Campaign, CampaignVariable } from "@spoke/spoke-codegen";
 import produce from "immer";
 import isEqual from "lodash/isEqual";
 import React, { useEffect, useState } from "react";
 import { compose } from "recompose";
 
-import type { Campaign } from "../../../../api/campaign";
 import type {
   InteractionStep,
   InteractionStepWithChildren
 } from "../../../../api/interaction-step";
-import type { Action } from "../../../../api/types";
 import { readClipboardText, writeClipboardText } from "../../../../client/lib";
 import ScriptPreviewButton from "../../../../components/ScriptPreviewButton";
 import { dataTest } from "../../../../lib/attributes";
@@ -72,7 +70,7 @@ interface HocProps {
       "id" | "isStarted" | "customFields" | "externalSystem"
     > & {
       interactionSteps: InteractionStepWithLocalState[];
-      campaignVariables: CampaignVariablePage;
+      campaignVariables: CampaignVariable[];
     };
   };
   availableActions: {
@@ -279,18 +277,16 @@ const CampaignInteractionStepsForm: React.FC<InnerProps> = (props) => {
       campaign: {
         customFields,
         invalidScriptFields,
-        campaignVariables: { edges: campaignVariableEdges },
+        campaignVariables,
         externalSystem
       } = {
         customFields: [],
-        campaignVariables: { edges: [] },
+        campaignVariables: [],
         externalSystem: null
       }
     },
     availableActions: { availableActions }
   } = props;
-
-  const campaignVariables = campaignVariableEdges.map(({ node }) => node);
 
   const {
     interactionSteps,

--- a/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
+++ b/src/containers/AdminCampaignEdit/sections/CampaignInteractionStepsForm/resolvers.ts
@@ -37,13 +37,9 @@ export const GET_CAMPAIGN_INTERACTIONS = gql`
       customFields
       invalidScriptFields
       campaignVariables {
-        edges {
-          node {
-            id
-            name
-            value
-          }
-        }
+        id
+        name
+        value
       }
       externalSystem {
         id

--- a/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
@@ -15,9 +15,9 @@ import {
   useEditCampaignVariablesMutation,
   useGetCampaignVariablesQuery
 } from "@spoke/spoke-codegen";
-import sortBy from "lodash/sortBy";
 import React, { useCallback, useMemo } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
+import { sortCampaignVariables } from "src/api/campaign-variable";
 
 import { allScriptFields, VARIABLE_NAME_REGEXP } from "../../../lib/scripts";
 import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";
@@ -73,17 +73,19 @@ const CampaignVariablesForm: React.FC<FullComponentProps> = (props) => {
   } = useGetCampaignVariablesQuery({
     variables: { campaignId },
     onCompleted: (data) => {
-      const nodes =
-        data?.campaign?.campaignVariables.edges.map(({ node }) => node) ?? [];
-      const campaignVariables = sortBy(
-        nodes.map((campaignVariable) => ({
-          displayOrder: campaignVariable.displayOrder,
-          name: campaignVariable.name.replace("cv:", ""),
-          value: campaignVariable.value ?? ""
-        })),
-        ["displayOrder"]
-      );
+      const unsortedCampaignVariables = data?.campaign?.campaignVariables;
 
+      const noPrefixCampaignVariables =
+        unsortedCampaignVariables?.map((campaignVariable) => {
+          return {
+            ...campaignVariable,
+            name: campaignVariable.name.replace("cv:", "")
+          };
+        }) ?? [];
+
+      const campaignVariables = sortCampaignVariables(
+        noPrefixCampaignVariables
+      );
       // Wait for useForm's subscription to be ready before reset() sends a signal to flush form state update
       setTimeout(() => {
         reset({ campaignVariables });

--- a/src/containers/AssignmentTexterContact/components/ApplyTagDialog.tsx
+++ b/src/containers/AssignmentTexterContact/components/ApplyTagDialog.tsx
@@ -31,7 +31,7 @@ export interface ApplyTagDialogProps {
     removedTags: ContactTagInfoFragment[]
   ) => Promise<void> | void;
   texter: User;
-  contact: Omit<CampaignContact, "tags">;
+  contact: CampaignContact;
 }
 
 const ApplyTagDialog: React.FC<ApplyTagDialogProps> = ({

--- a/src/containers/AssignmentTexterContact/index.jsx
+++ b/src/containers/AssignmentTexterContact/index.jsx
@@ -275,17 +275,14 @@ export class AssignmentTexterContact extends React.Component {
 
   getMessageTextFromScript = (script) => {
     const { campaign, contact, texter } = this.props;
-
-    const campaignVariables = campaign.campaignVariables.edges.map(
-      ({ node }) => node
-    );
+    const { customFields, campaignVariables } = campaign;
 
     return script
       ? applyScript({
           contact,
           texter,
           script,
-          customFields: campaign.customFields,
+          customFields,
           campaignVariables
         })
       : "";
@@ -333,8 +330,8 @@ export class AssignmentTexterContact extends React.Component {
   createMessageToContact = (text) => {
     const { texter, campaign, assignment } = this.props;
     const { contact } = this.props;
-    const campaignVariableIds = campaign.campaignVariables.edges.map(
-      ({ node: { id } }) => id
+    const campaignVariableIds = campaign.campaignVariables.map(
+      (campaignVariable) => campaignVariable.id
     );
 
     return {

--- a/src/containers/TexterTodo/index.jsx
+++ b/src/containers/TexterTodo/index.jsx
@@ -152,14 +152,11 @@ const queries = {
             }
             customFields
             campaignVariables {
-              edges {
-                node {
-                  id
-                  name
-                  value
-                }
-              }
+              id
+              name
+              value
             }
+
             interactionSteps {
               id
               parentInteractionId

--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -88,7 +88,7 @@ interface ApplyScriptOptions {
   script: string;
   contact: CampaignContact;
   customFields: string[];
-  campaignVariables: { name: string; value: string }[];
+  campaignVariables: Pick<CampaignVariable, "name" | "value">[];
   texter: User;
 }
 
@@ -110,17 +110,11 @@ export const applyScript = ({
     );
   }
 
-  for (const field of campaignVariables) {
-    const re = new RegExp(escapeRegExp(delimit(field.name)), "g");
-    appliedScript = appliedScript.replace(re, field.value);
-  }
-
-  for (const field of campaignVariables) {
-    const re = new RegExp(
-      escapeRegExp(delimit(field.name.replace("cv:", ""))),
-      "g"
-    );
-    appliedScript = appliedScript.replace(re, field.value);
+  for (const campaignVariable of campaignVariables) {
+    if (campaignVariable.value) {
+      const re = new RegExp(escapeRegExp(delimit(campaignVariable.name)), "g");
+      appliedScript = appliedScript.replace(re, campaignVariable.value);
+    }
   }
 
   return appliedScript;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -665,7 +665,7 @@ type Campaign {
   editors: String
   teams: [Team!]!
   campaignGroups: CampaignGroupPage
-  campaignVariables: CampaignVariablePage!
+  campaignVariables: [CampaignVariable!]!
   textingHoursStart: Int
   textingHoursEnd: Int
   isAutoassignEnabled: Boolean!
@@ -736,7 +736,7 @@ input CampaignInput {
   introHtml: String
   externalSystemId: String
   useDynamicAssignment: Boolean
-  contacts: [CampaignContactInput]
+  contacts: [CampaignContactInput!]
   contactsFile: Upload
   externalListId: String
   filterOutLandlines: Boolean
@@ -749,7 +749,7 @@ input CampaignInput {
   campaignVariables: [CampaignVariableInput!]
   texters: TexterInput
   interactionSteps: InteractionStepInput
-  cannedResponses: [CannedResponseInput]
+  cannedResponses: [CannedResponseInput!]
   textingHoursStart: Int
   textingHoursEnd: Int
   isAutoassignEnabled: Boolean
@@ -968,8 +968,6 @@ type CampaignContactTag {
   id: String!
   tag: Tag!
   tagger: User!
-  createdAt: String!
-  updatedAt: String!
 }
 
 
@@ -1013,18 +1011,6 @@ type CampaignVariable {
   displayOrder: Int!
   name: String!
   value: String
-  createdAt: String!
-  updatedAt: String!
-}
-
-type CampaignVariableEdge {
-  cursor: Cursor!
-  node: CampaignVariable!
-}
-
-type CampaignVariablePage {
-  edges: [CampaignVariableEdge!]!
-  pageInfo: RelayPageInfo!
 }
 
 

--- a/src/server/api/campaign-contact-tag.ts
+++ b/src/server/api/campaign-contact-tag.ts
@@ -1,5 +1,4 @@
 import { r } from "../models";
-import { sqlResolvers } from "./lib/utils";
 import type { TagRecord, UserRecord } from "./types";
 
 interface CampaignContactTagRecord {
@@ -15,7 +14,6 @@ interface CampaignContactTagRecordPreloaded extends CampaignContactTagRecord {
 
 export const resolvers = {
   CampaignContactTag: {
-    ...sqlResolvers(["createdAt", "updatedAt"]),
     tag: async (cct: CampaignContactTagRecordPreloaded) =>
       cct.tag ? cct.tag : r.reader("tag").where({ id: cct.tag_id }).first(),
     tagger: async (cct: CampaignContactTagRecordPreloaded) =>

--- a/src/server/api/campaign-variable.ts
+++ b/src/server/api/campaign-variable.ts
@@ -2,14 +2,7 @@ import { sqlResolvers } from "./lib/utils";
 
 export const resolvers = {
   CampaignVariable: {
-    ...sqlResolvers([
-      "id",
-      "displayOrder",
-      "name",
-      "value",
-      "createdAt",
-      "updatedAt"
-    ])
+    ...sqlResolvers(["id", "displayOrder", "name", "value"])
   }
 };
 

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -813,17 +813,16 @@ export const resolvers = {
       const result = await formatPage(query, { after, first });
       return result;
     },
-    campaignVariables: async (campaign, { after, first }, { user }) => {
+    campaignVariables: async (campaign, _, { user }) => {
+      console.log(campaign);
       const organizationId = parseInt(campaign.organization_id, 10);
       await accessRequired(user, organizationId, UserRoleType.TEXTER);
 
-      const query = r
+      return r
         .reader("campaign_variable")
         .where({ campaign_id: campaign.id })
         .whereNull("deleted_at")
         .select("*");
-      const result = await formatPage(query, { after, first });
-      return result;
     },
     autosendStatus: async (campaign) => {
       const {

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -814,7 +814,6 @@ export const resolvers = {
       return result;
     },
     campaignVariables: async (campaign, _, { user }) => {
-      console.log(campaign);
       const organizationId = parseInt(campaign.organization_id, 10);
       await accessRequired(user, organizationId, UserRoleType.TEXTER);
 

--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -547,7 +547,9 @@ export const editCampaign = async (
       filterOutLandlines: campaign.filterOutLandlines,
       validationStats
     };
-    const compressedString = await gzip(JSON.stringify(jobPayload));
+    const compressedString: Buffer = (await gzip(
+      JSON.stringify(jobPayload)
+    )) as Buffer;
     const [job] = await r
       .knex("job_request")
       .insert({
@@ -607,7 +609,7 @@ export const editCampaign = async (
       // Remove all existing team memberships and then add everything again
       await trx("campaign_team").where({ campaign_id: id }).del();
       await trx("campaign_team").insert(
-        campaign.teamIds.map((team_id) => ({
+        campaign.teamIds?.map((team_id) => ({
           team_id,
           campaign_id: id
         }))
@@ -756,7 +758,7 @@ export const editCampaign = async (
     await unstartIfNecessary();
 
     // Ignore the mocked `id` automatically created on the input by GraphQL
-    const convertedResponses = campaign.cannedResponses.map(
+    const convertedResponses = campaign.cannedResponses?.map(
       ({
         id: _cannedResponseId,
         displayOrder,

--- a/src/server/tasks/retry-interaction-step.ts
+++ b/src/server/tasks/retry-interaction-step.ts
@@ -65,9 +65,7 @@ export const retryInteractionStep: Task = async (
   const { campaign_contact, interaction_step, assignment_id, user } = record;
 
   const { rows: campaignVariables } = await helpers.query<
-    Pick<CampaignVariableRecord, "id" | "name"> & {
-      value: NonNullable<CampaignVariableRecord["value"]>;
-    }
+    CampaignVariableRecord
   >(
     "select * from campaign_variable where campaign_id = $1 and deleted_at is null",
     [campaign_contact.campaign_id]

--- a/src/server/tasks/retry-interaction-step.ts
+++ b/src/server/tasks/retry-interaction-step.ts
@@ -1,3 +1,4 @@
+import type { CampaignContact, MessageInput, User } from "@spoke/spoke-codegen";
 import type { Task } from "graphile-worker";
 import sample from "lodash/sample";
 import md5 from "md5";
@@ -80,7 +81,7 @@ export const retryInteractionStep: Task = async (
   };
   const texter = recordToCamelCase<User>(user);
   const customFields = Object.keys(JSON.parse(contact.customFields));
-  const campaignVariableIds = campaignVariables.map(({ id }) => id);
+  const campaignVariableIds = campaignVariables.map(({ id }) => id.toString());
 
   const body = applyScript({
     script,

--- a/src/server/tasks/retry-interaction-step.ts
+++ b/src/server/tasks/retry-interaction-step.ts
@@ -3,9 +3,6 @@ import type { Task } from "graphile-worker";
 import sample from "lodash/sample";
 import md5 from "md5";
 
-import type { CampaignContact } from "../../api/campaign-contact";
-import type { MessageInput } from "../../api/types";
-import type { User } from "../../api/user";
 import { recordToCamelCase } from "../../lib/attributes";
 import { applyScript } from "../../lib/scripts";
 import { sendMessage } from "../api/lib/send-message";


### PR DESCRIPTION
## Description

This PR cleans up some typing across a few places:
1. [`CampaignContactTag`](libs/gql-schema/campaign-contact-tag.ts): Removing unused created at and updated at fields for simplified conversion to Tag type where needed
2. [`CampaignVariable`](libs/gql-schema/campaign-variable.ts): Removing unused pagination
3. [`CampaignInput`](libs/gql-schema/campaign.ts): Use arrays of non-optional canned responses and campaign contacts
4. [`campaign.ts`](src/server/api/lib/campaign.ts): misc. typing

## Motivation and Context

Prep for bug fix PR to come

## How Has This Been Tested?

This has been tested locally:
1. Tags - texter, message review (there is an existing bug to fix here
2. Campaign Variables - texter, campaign builder, script preview
3. Campaign Builder - Loading contacts, adding canned responses

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
