### PR TITLE
refactor(message review): fetch messages instead of using state

### DIFF
--- a/libs/spoke-codegen/src/graphql/message-review.graphql
+++ b/libs/spoke-codegen/src/graphql/message-review.graphql
@@ -77,6 +77,14 @@ query GetConversationsForMessageReview(
   }
 }
 
+query GetMessagesForContact($campaignContactId: String!) {
+  contact (id: $campaignContactId) {
+    messages {
+      ...ConversationMessage
+    }
+  }
+}
+
 mutation CloseConversation($campaignContactId: String!) {
   editCampaignContactMessageStatus(
     campaignContactId: $campaignContactId

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/MessageResponse.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/MessageResponse.tsx
@@ -4,23 +4,23 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import type {
+  ConversationInfoFragment,
+  MessageInput
+} from "@spoke/spoke-codegen";
 import { useSendMessageMutation } from "@spoke/spoke-codegen";
 import React, { useState } from "react";
 import * as yup from "yup";
 
-import type { Conversation } from "../../../../../api/conversations";
-import type { Message } from "../../../../../api/message";
-import type { MessageInput } from "../../../../../api/types";
 import GSForm from "../../../../../components/forms/GSForm";
 import SpokeFormField from "../../../../../components/forms/SpokeFormField";
 import MessageLengthInfo from "../../../../../components/MessageLengthInfo";
 import SendButton from "../../../../../components/SendButton";
 
 interface MessageResponseProps {
-  conversation: Conversation;
+  conversation: ConversationInfoFragment;
   value?: string;
   onChange?: (value: string) => Promise<void> | void;
-  messagesChanged(messages: Message[]): Promise<void> | void;
 }
 
 const messageSchema = yup.object({
@@ -53,10 +53,14 @@ const MessageResponse: React.FC<MessageResponseProps> = ({
     };
   };
 
-  const handleMessageFormChange = ({ messageText }: MessageFormValue) =>
+  const handleMessageFormChange = ({ messageText }: { messageText: string }) =>
     onChange?.(messageText);
 
-  const handleMessageFormSubmit = async ({ messageText }: MessageFormValue) => {
+  const handleMessageFormSubmit = async ({
+    messageText
+  }: {
+    messageText: string;
+  }) => {
     const { contact } = conversation;
     const message: MessageInput = createMessageToContact(messageText);
     if (isSending) {

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/MessageResponse.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/MessageResponse.tsx
@@ -33,8 +33,7 @@ const messageSchema = yup.object({
 const MessageResponse: React.FC<MessageResponseProps> = ({
   conversation,
   value,
-  onChange,
-  messagesChanged
+  onChange
 }: MessageResponseProps) => {
   const [isSending, setIsSending] = useState<boolean>(false);
   const [sendError, setSendError] = useState<string>("");
@@ -79,10 +78,7 @@ const MessageResponse: React.FC<MessageResponseProps> = ({
         setSendError(errorMsgs);
       }
 
-      if (messages) {
-        messagesChanged(messages);
-        onChange?.("");
-      }
+      if (messages) onChange?.("");
     } catch (e: any) {
       setSendError(e.message);
     } finally {

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/index.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/index.tsx
@@ -1,11 +1,9 @@
 import Button from "@material-ui/core/Button";
 import Grid from "@material-ui/core/Grid";
-import type {
-  ConversationInfoFragment,
-  ConversationMessageFragment
-} from "@spoke/spoke-codegen";
+import type { ConversationInfoFragment } from "@spoke/spoke-codegen";
+import { useGetMessagesForContactQuery } from "@spoke/spoke-codegen";
 import isNil from "lodash/isNil";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import CannedResponseMenu from "src/components/CannedResponseMenu";
 
 import MessageList from "./MessageList";
@@ -36,12 +34,11 @@ const MessageColumn: React.FC<Props> = (props) => {
   const [isOptedOut, setIsOptedOut] = useState(
     !isNil(conversation.contact.optOut?.cell)
   );
-  // TODO: use apollo client cache rather than state to manage changes to messages list
-  const [messages, setMessages] = useState<ConversationMessageFragment[]>([]);
 
-  useEffect(() => {
-    setMessages(conversation.contact.messages);
-  }, [setMessages]);
+  const { data: messageData } = useGetMessagesForContactQuery({
+    variables: { campaignContactId: contact.id }
+  });
+  const messages = messageData?.contact?.messages ?? [];
 
   const handleOpenCannedResponse: ClickButtonHandler = useCallback(
     (event) => {
@@ -71,7 +68,6 @@ const MessageColumn: React.FC<Props> = (props) => {
           <MessageResponse
             value={messageText}
             conversation={conversation}
-            messagesChanged={setMessages}
             onChange={setMessageText}
           />
         )}

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/index.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/index.tsx
@@ -38,7 +38,7 @@ const MessageColumn: React.FC<Props> = (props) => {
   const { data: messageData } = useGetMessagesForContactQuery({
     variables: { campaignContactId: contact.id }
   });
-  const messages = messageData?.contact?.messages ?? [];
+  const messages = messageData?.contact?.messages ?? contact.messages;
 
   const handleOpenCannedResponse: ClickButtonHandler = useCallback(
     (event) => {


### PR DESCRIPTION
## Description

This refactors message review to fetch messages for a conversation rather than managing the list of messages via state management

## Motivation and Context

TODO comment

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
