### PR TITLE
feat: hide inactive orgs on select org screen

### DIFF
--- a/libs/gql-schema/user.ts
+++ b/libs/gql-schema/user.ts
@@ -6,7 +6,7 @@ export const schema = `
     displayName: String!
     email: String
     cell: String
-    memberships(organizationId: String, after: Cursor, first: Int): OrganizationMembershipPage
+    memberships(organizationId: String, after: Cursor, first: Int, active: Boolean): OrganizationMembershipPage
     organizations(active: Boolean, role: String): [Organization]
     todos(organizationId: String): [Assignment]
     roles(organizationId: String!): [UserRole!]!

--- a/libs/spoke-codegen/src/graphql/session.graphql
+++ b/libs/spoke-codegen/src/graphql/session.graphql
@@ -42,6 +42,27 @@ query GetCurrentUserForMenu {
   }
 }
 
+query GetCurrentUserForOrganizationList {
+  currentUser {
+    id
+    memberships (active: true) {
+      edges {
+        node {
+          id
+          role
+          organization {
+            id
+            name
+            myCurrentAssignmentTargets {
+              maxRequestCount
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 query GetCurrentUserRoles($organizationId: String!) {
   currentUser {
     id

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -353,7 +353,7 @@ type User {
   displayName: String!
   email: String
   cell: String
-  memberships(organizationId: String, after: Cursor, first: Int): OrganizationMembershipPage
+  memberships(organizationId: String, after: Cursor, first: Int, active: Boolean): OrganizationMembershipPage
   organizations(active: Boolean, role: String): [Organization]
   todos(organizationId: String): [Assignment]
   roles(organizationId: String!): [UserRole!]!

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -191,7 +191,7 @@ export const resolvers = {
         .then((record) => record || null),
     memberships: async (
       user,
-      { organizationId, after, first },
+      { organizationId, after, first, active },
       { user: authUser }
     ) => {
       if (authUser.id !== user.id && !authUser.is_superadmin) {
@@ -205,9 +205,14 @@ export const resolvers = {
       }
 
       const query = r.reader("user_organization").where({ user_id: user.id });
-      if (organizationId) {
-        query.where({ organization_id: organizationId });
+      if (organizationId) query.where({ organization_id: organizationId });
+
+      if (active) {
+        query.whereRaw(
+          "exists (select 1 from organization o where o.id = organization_id and deleted_at is null)"
+        );
       }
+
       return formatPage(query, { after, first });
     },
     organizations: async (user, { role, active = true }) => {


### PR DESCRIPTION
## Description

This hides inactive orgs on the "select your organization" screen seen when initially logging in

## Motivation and Context

User feedback that this list tends to be very long for instances that have a lot of inactive orgs

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
