### PR TITLE
chore: replace spoke chip with mui chip

### DIFF
--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -1,4 +1,5 @@
 import { withApollo } from "@apollo/client/react/hoc";
+import Chip from "@material-ui/core/Chip";
 import { blue, green, grey, orange, red } from "@material-ui/core/colors";
 import type { CampaignVariable } from "@spoke/spoke-codegen";
 import { IsValidAttachmentDocument } from "@spoke/spoke-codegen";
@@ -16,7 +17,6 @@ import React from "react";
 import { getSpokeCharCount, replaceEasyGsmWins } from "../lib/charset-utils";
 import { delimit, getAttachmentLink, getMessageType } from "../lib/scripts";
 import baseTheme from "../styles/theme";
-import Chip from "./Chip";
 
 type DecoratorStrategyCallBack = (start: number, end: number) => void;
 
@@ -54,10 +54,10 @@ const styles: Record<string, React.CSSProperties> = {
     color: red[400]
   },
   scriptFieldButton: {
-    fontSize: "11px",
     textTransform: "none",
     backgroundColor: grey[100],
-    cursor: "pointer"
+    cursor: "pointer",
+    margin: 5
   },
   customField: {
     color: green[800]
@@ -346,7 +346,7 @@ class ScriptEditor extends React.Component<Props, State> {
           <Chip
             key={field}
             style={{ ...styles.scriptFieldButton, ...styles.customField }}
-            text={delimit(field)}
+            label={delimit(field)}
             onClick={() => this.addCustomField(field)}
           />
         ))}
@@ -359,7 +359,7 @@ class ScriptEditor extends React.Component<Props, State> {
                 ? styles.invalidCampaignVariableField
                 : styles.validCampaignVariableField)
             }}
-            text={delimit(field.name)}
+            label={delimit(field.name)}
             onClick={() => this.addCustomField(field.name)}
           />
         ))}


### PR DESCRIPTION
## Description

This replaces the custom Spoke `Chip` component (which is only used to display custom fields in the Script Editor) with the standard MUI component

## Motivation and Context

Prefer using one set of components 😁 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/76596635/192122228-1a7c94ef-6995-4d90-96fc-55b6e157ba46.png"/></td>
<td><img src="https://github.com/With-the-Ranks/Spoke/assets/76596635/08edf62b-ad70-438b-9645-8383d26165c7"/></td>
</tr>
</table>

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
