### PR TITLE
fix: use wtr mms doc link

### DIFF
--- a/src/components/Links/IncludeImageDocLink.tsx
+++ b/src/components/Links/IncludeImageDocLink.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import { LinkInNewTab } from "./LinkInNewTab";
+
+export interface IncludeImageDocLinkProps {
+  text: string;
+}
+
+const IMAGE_DOC_LINK =
+  "https://withtheranks.com/docs/spoke/for-spoke-admins/include-an-image-in-a-message";
+
+export const IncludeImageDocLink: React.FC<IncludeImageDocLinkProps> = ({
+  text
+}) => <LinkInNewTab link={IMAGE_DOC_LINK} text={text} />;

--- a/src/components/Links/LinkInNewTab.tsx
+++ b/src/components/Links/LinkInNewTab.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export interface LinkInNewTabProps {
+  text: string;
+  link: string;
+}
+
+export const LinkInNewTab: React.FC<LinkInNewTabProps> = ({ text, link }) => (
+  <a href={link} target="_blank" rel="noopener noreferrer">
+    {text}
+  </a>
+);

--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -17,6 +17,7 @@ import { getSpokeCharCount, replaceEasyGsmWins } from "../lib/charset-utils";
 import { delimit, getAttachmentLink, getMessageType } from "../lib/scripts";
 import baseTheme from "../styles/theme";
 import Chip from "./Chip";
+import { IncludeImageDocLink } from "./Links/IncludeImageDocLink";
 
 type DecoratorStrategyCallBack = (start: number, end: number) => void;
 
@@ -325,14 +326,8 @@ class ScriptEditor extends React.Component<Props, State> {
         <div style={{ color: baseTheme.colors.red }}>
           WARNING! The media attachment URL is of an unsupported MMS type.
           Please check the URL of the attachment or see{" "}
-          <a
-            href="https://docs.spokerewired.com/article/86-include-an-image-in-a-message"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Include an Image in a Message
-          </a>{" "}
-          for all supported types.
+          <IncludeImageDocLink text="Include an Image in a Message" /> for all
+          supported types.
         </div>
       );
     }

--- a/src/containers/Settings/components/MessageSendingSettingsCard.tsx
+++ b/src/containers/Settings/components/MessageSendingSettingsCard.tsx
@@ -10,7 +10,8 @@ import {
   useUpdateMessageSendingSettingsMutation
 } from "@spoke/spoke-codegen";
 import React from "react";
-import { IncludeImageDocLink } from "src/components/Links/IncludeImageDocLink";
+
+import { IncludeImageDocLink } from "../../../components/Links/IncludeImageDocLink";
 
 export interface MessageSendingSettingsCardProps {
   organizationId: string;

--- a/src/containers/Settings/components/MessageSendingSettingsCard.tsx
+++ b/src/containers/Settings/components/MessageSendingSettingsCard.tsx
@@ -10,6 +10,7 @@ import {
   useUpdateMessageSendingSettingsMutation
 } from "@spoke/spoke-codegen";
 import React from "react";
+import { IncludeImageDocLink } from "src/components/Links/IncludeImageDocLink";
 
 export interface MessageSendingSettingsCardProps {
   organizationId: string;
@@ -84,13 +85,7 @@ export const MessageSendingSettingsCard: React.FC<MessageSendingSettingsCardProp
           Messages longer than 3 segments are usually cheaper to send as MMS.
           You may notice changes in deliverability when switching from SMS to
           MMS messages.{" "}
-          <a
-            href="https://docs.spokerewired.com/article/86-include-an-image-in-a-message"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Learn more about sending MMS here
-          </a>
+          <IncludeImageDocLink text="Learn more about sending MMS here" />
         </p>
         <FormControlLabel
           label="Convert long SMS messages to MMS?"


### PR DESCRIPTION
## Description

This changes relevant links to point to this article: https://withtheranks.com/docs/spoke/for-spoke-admins/include-an-image-in-a-message

## Motivation and Context

Replacing dead link

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
