### PR TITLE
fix(exports): materialize campaign contacts

### DIFF
--- a/src/server/tasks/export-campaign.ts
+++ b/src/server/tasks/export-campaign.ts
@@ -185,13 +185,21 @@ export const processContactsChunk = async (
   lastContactId = 0,
   onlyOptOuts = false
 ): Promise<ContactsChunk | false> => {
+  // HACK - we shouldn't need to materialize the campaign contacts
+  // this gets around a problem with query planning where
+  // the campaign_id index isn't used on some instances
   const { rows }: { rows: ContactExportRow[] } = await r.reader.raw(
     `
-      with campaign_contacts as (
+      with materialized_contacts as materialized (
         select *
         from campaign_contact
         where
           campaign_id = ?
+      ),
+      campaign_contacts as (
+        select *
+        from materialized_contacts
+        where true
           and id > ?
           ${onlyOptOuts ? "and is_opted_out = true" : ""}
         order by


### PR DESCRIPTION
## Description

This materializes campaign contacts while preparing exports, to resolve an issue on some instances with query planning in production

## Motivation and Context

See production issue reported here https://withtheranks.slack.com/archives/C0694QK8A3X/p1723067594475649?thread_ts=1723062179.129459&cid=C0694QK8A3X

## How Has This Been Tested?

The code change has been tested locally, and the expected query output has been tested on the production instance to confirm it avoids the query planning issue

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
