### PR TITLE
fix: only mark contact as messaged after initial

### DIFF
--- a/src/server/api/lib/send-message.ts
+++ b/src/server/api/lib/send-message.ts
@@ -307,7 +307,10 @@ export const sendMessage = async (
       await trx("campaign_contact")
         .update({
           message_status:
-            cc_message_status === "needsMessage" ? "messaged" : "convo"
+            cc_message_status === "needsMessage" ||
+            cc_message_status === "messaged"
+              ? "messaged"
+              : "convo"
         })
         .where({ id: record.cc_id });
     }

--- a/src/server/api/lib/send-message.ts
+++ b/src/server/api/lib/send-message.ts
@@ -307,10 +307,7 @@ export const sendMessage = async (
       await trx("campaign_contact")
         .update({
           message_status:
-            cc_message_status === "needsResponse" ||
-            cc_message_status === "convo"
-              ? "convo"
-              : "messaged"
+            cc_message_status === "needsMessage" ? "messaged" : "convo"
         })
         .where({ id: record.cc_id });
     }


### PR DESCRIPTION
## Description

This updates message sending so that the behavior of updating `campaign_contact.message_status` reflects the most common interpretation of how this should work by admins:
1. After an initial message is sent (the previous `message_status` is `needsMessage`), the status should be updated to `messaged`
2. Any other time a Spoke user sends a message, the status should be updated to "active conversation" (`convo`)

Edit: It's possible to send a message to a contact marked as `messaged` via Message Review - in this case we want to keep the `messaged` status


## Motivation and Context

See context for bug find here: https://withtheranks.slack.com/archives/C01L3B18S10/p1723131234467449?thread_ts=1723060316.173739&cid=C01L3B18S10

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
