### PR TITLE
chore: simplify calculation of filtered contacts task status

### DIFF
--- a/src/server/tasks/chunk-tasks/export-campaign/index.ts
+++ b/src/server/tasks/chunk-tasks/export-campaign/index.ts
@@ -495,9 +495,7 @@ const processAndUploadFilteredContacts: ExportCampaignTask<UploadContactsPayload
       chunkSize: CHUNK_SIZE,
       helpers,
       contactsCount,
-      writeResult: writeExportResult(writeStream),
-      statusDivider: 4,
-      statusOffset: 75
+      writeResult: writeExportResult(writeStream)
     });
   } finally {
     writeStream.end();


### PR DESCRIPTION
## Description

This simplifies the calculation for how close to completion the filtered contacts export is:

The relevant code from [`processChunks`](https://github.com/With-the-Ranks/Spoke/blob/096ad161468795080fb7d2bab53544a060b9e9e6/src/server/tasks/chunk-tasks/utils.ts#L110):
```typescript
  const newStatus =
      Math.round((processed / contactsCount / statusDivider) * 100) +
      statusOffset;
    await helpers.updateStatus(newStatus);
```
Previously, for the filtered contacts export, this would look like:
```typescript
  const newStatus =
      Math.round((processed / contactsCount / 4) * 100) + 75;
    await helpers.updateStatus(newStatus);
```

Now instead, this is simplified to:
```typescript
  const newStatus =
      Math.round((processed / contactsCount) * 100)
    await helpers.updateStatus(newStatus);
```


## Motivation and Context

Makes this section of code easier to understand when debugging

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
