### PR TITLE
test: add test suite for mark second pass

### DIFF
--- a/src/server/mail.ts
+++ b/src/server/mail.ts
@@ -44,7 +44,7 @@ export const sendEmail = async (options: SendMailOptions) => {
     params.replyTo = replyTo;
   }
 
-  if (config.isDevelopment) {
+  if (!config.isProduction) {
     logger.info(`Would send e-mail with params`, { params });
     return null;
   }

--- a/src/server/tasks/chunk-tasks/mark-second-pass/mark-second-pass.spec.ts
+++ b/src/server/tasks/chunk-tasks/mark-second-pass/mark-second-pass.spec.ts
@@ -1,0 +1,147 @@
+import {
+  createCompleteCampaign,
+  createMessage
+} from "__test__/testbed-preparation/core";
+import { runTaskListOnce } from "graphile-worker";
+import { Pool } from "pg";
+
+import { config } from "../../../../config";
+import { MessageStatusType } from "../../../api/types";
+import { withClient } from "../../../utils";
+import { markSecondPass, TASK_IDENTIFIER } from ".";
+import type { MarkSecondPassPayload } from "./utils";
+
+interface TestSecondPassMarkingOptions {
+  unmark?: boolean;
+  createInitials?: boolean;
+  markNeedsResponse?: boolean;
+  testExcludeNewer?: boolean;
+  testExcludeRecentlyTexted?: boolean;
+}
+
+const testSecondPassMarking = async (
+  pool: Pool,
+  options: TestSecondPassMarkingOptions
+) => {
+  const NUM_CONTACTS = 5;
+  const {
+    unmark,
+    createInitials,
+    markNeedsResponse,
+    testExcludeNewer,
+    testExcludeRecentlyTexted
+  } = options;
+
+  await withClient(pool, async (client) => {
+    const campaign = await createCompleteCampaign(client, {
+      contacts: Array(NUM_CONTACTS).fill({
+        messageStatus: markNeedsResponse
+          ? MessageStatusType.NeedsResponse
+          : unmark
+          ? MessageStatusType.NeedsMessage
+          : MessageStatusType.Messaged
+      }),
+      texters: 1
+    });
+
+    const { contacts, assignments } = campaign;
+
+    if (createInitials) {
+      for (const contact of contacts) {
+        await createMessage(client, {
+          campaignContactId: contact.id,
+          assignmentId: assignments[0].id
+        });
+      }
+    }
+
+    if (testExcludeNewer) {
+      await createCompleteCampaign(client, { contacts });
+    }
+
+    const { id: campaignId, title: campaignTitle } = campaign.campaign;
+
+    const payload: MarkSecondPassPayload = {
+      organizationId: campaign.organization.id,
+      campaignId,
+      campaignTitle,
+      requesterId: campaign.texters[0].id,
+      unmark,
+      excludeNewer: testExcludeNewer
+    };
+    if (testExcludeRecentlyTexted) payload.excludeAgeInHours = 1;
+
+    await client.query(`select graphile_worker.add_job($1, $2)`, [
+      TASK_IDENTIFIER,
+      payload
+    ]);
+
+    await runTaskListOnce(
+      { pgPool: pool },
+      { [TASK_IDENTIFIER]: markSecondPass },
+      client
+    );
+
+    const { rows: contactRows } = await client.query(
+      `
+          select message_status from campaign_contact
+          where campaign_id = $1;
+      `,
+      [campaignId]
+    );
+
+    const expectedStatus = markNeedsResponse
+      ? MessageStatusType.NeedsResponse
+      : testExcludeNewer ||
+        testExcludeRecentlyTexted ||
+        (unmark && createInitials)
+      ? MessageStatusType.Messaged
+      : MessageStatusType.NeedsMessage;
+
+    for (const contact of contactRows)
+      expect(contact.message_status).toBe(expectedStatus);
+  });
+};
+
+describe("second pass marking", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: config.TEST_DATABASE_URL });
+  });
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+  });
+
+  it("marks second pass for all messaged contacts", async () => {
+    testSecondPassMarking(pool, {});
+  });
+
+  it("unmarks second pass for contacts with initial sent", async () => {
+    testSecondPassMarking(pool, { unmark: true, createInitials: true });
+  });
+
+  it("unmark second pass doesn't affect contacts without initial sent", async () => {
+    testSecondPassMarking(pool, { unmark: true, createInitials: false });
+  });
+
+  it("mark second pass doesn't affect contacts marked as needs response", async () => {
+    testSecondPassMarking(pool, { markNeedsResponse: true });
+  });
+
+  it("unmark second pass doesn't affect contacts marked as needs response", async () => {
+    testSecondPassMarking(pool, { unmark: true, markNeedsResponse: true });
+  });
+
+  it("mark second pass excludes contacts on newer campaign when specified", async () => {
+    testSecondPassMarking(pool, { testExcludeNewer: true });
+  });
+
+  it("mark second pass excludes recently texted contacts when specified", async () => {
+    testSecondPassMarking(pool, {
+      createInitials: true,
+      testExcludeRecentlyTexted: true
+    });
+  });
+});

--- a/src/server/tasks/chunk-tasks/utils.ts
+++ b/src/server/tasks/chunk-tasks/utils.ts
@@ -1,3 +1,4 @@
+import { config } from "../../../config";
 import { r } from "../../models";
 import type { ProgressJobPayload, ProgressTaskHelpers } from "../utils";
 
@@ -110,8 +111,8 @@ export const processChunks = async (payload: ProcessChunksPayload) => {
     const newStatus =
       Math.round((processed / contactsCount / statusDivider) * 100) +
       statusOffset;
-    await helpers.updateStatus(newStatus);
 
+    if (!config.isTest) await helpers.updateStatus(newStatus);
     if (writeResult) writeResult(chunkResult);
   }
 };


### PR DESCRIPTION
## Description

This adds a test suite for all mark second pass functionality

## Motivation and Context

Follow up to #46 

## How Has This Been Tested?

Tests added in this PR

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
