### PR TITLE
fix: remove new query parameter when create new campaign

### DIFF
--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -17,7 +17,6 @@ import { CampaignBuilderMode } from "@spoke/spoke-codegen";
 import isEqual from "lodash/isEqual";
 import pick from "lodash/pick";
 import PropTypes from "prop-types";
-import queryString from "query-string";
 import React from "react";
 import { Helmet } from "react-helmet";
 import { compose } from "recompose";
@@ -61,9 +60,7 @@ import CampaignVariablesForm from "./sections/CampaignVariablesForm";
 class AdminCampaignEdit extends React.Component {
   constructor(props) {
     super(props);
-    const isNew = queryString.parse(props.location.search).new;
     this.state = {
-      expandedSection: isNew ? 0 : null,
       campaignFormValues: { ...props.campaignData.campaign },
       startingCampaign: false,
       isWorking: false,
@@ -144,10 +141,6 @@ class AdminCampaignEdit extends React.Component {
     return sectionState;
   }
 
-  isNew = () => {
-    return Boolean(queryString.parse(this.props.location.search).new);
-  };
-
   handleDeleteJob = async (jobId) => {
     if (
       // eslint-disable-next-line no-alert,no-restricted-globals
@@ -175,8 +168,7 @@ class AdminCampaignEdit extends React.Component {
     await this.handleSave();
     this.setState({
       expandedSection:
-        this.state.expandedSection >= this.sections().length - 1 ||
-        !this.isNew()
+        this.state.expandedSection >= this.sections().length - 1
           ? null
           : this.state.expandedSection + 1
     }); // currently throws an unmounted component error in the console
@@ -654,14 +646,8 @@ class AdminCampaignEdit extends React.Component {
   renderCampaignFormSection = (section, forceDisable) => {
     const { isWorking } = this.state;
     const shouldDisable =
-      isWorking ||
-      forceDisable ||
-      (!this.isNew() && this.checkSectionSaved(section));
-    const saveLabel = isWorking
-      ? "Working..."
-      : this.isNew()
-      ? "Save and goto next section"
-      : "Save";
+      isWorking || forceDisable || this.checkSectionSaved(section);
+    const saveLabel = isWorking ? "Working..." : "Save";
     const ContentComponent = section.content;
     const formValues = this.getSectionState(section);
     return (
@@ -859,8 +845,7 @@ class AdminCampaignEdit extends React.Component {
     const { expandedSection, requestError } = this.state;
     const { isAdmin, match } = this.props;
     const { campaignId } = match.params;
-    const isNew = this.isNew();
-    const saveLabel = isNew ? "Save and goto next section" : "Save";
+    const saveLabel = "Save";
 
     const errorActions = [
       <Button key="ok" color="primary" onClick={this.handleCloseError}>
@@ -885,7 +870,6 @@ class AdminCampaignEdit extends React.Component {
                 organizationId={match.params.organizationId}
                 campaignId={campaignId}
                 active={expandedSection === sectionIndex}
-                isNew={isNew}
                 saveLabel={saveLabel}
                 onError={this.handleSectionError}
                 onExpandChange={this.handleExpandChange(sectionIndex)}

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -108,9 +108,7 @@ class AdminCampaignList extends React.Component {
     }
 
     const { id: campaignId } = newCampaign.data.createCampaign;
-    history.push(
-      `/admin/${organizationId}/campaigns/${campaignId}/edit?new=true`
-    );
+    history.push(`/admin/${organizationId}/campaigns/${campaignId}/edit`);
   };
 
   handleFilterChange = (event, index, value) => {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Removes the new=true query parameter from the URL when creating a new campaign, addressing unexpected navigation behavior in the campaign builder.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change resolves the issue where the new=true query parameter forces admins back to the Basics tab upon saving another section, interrupting the intended flow when filling out sections in any order. See issue [#56](https://github.com/With-the-Ranks/Spoke/issues/56) for details.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested by creating a new campaign, navigating between sections, and confirming no forced navigation back to the Basics tab after saving.

## Additional Notes:

The AdminCampaignEdit component still retains the isNew prop, which is currently unused but related to the removed new=true query parameter.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
