### PR TITLE
fix: fix loading of archived campaigns

### DIFF
--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -314,7 +314,7 @@ class AdminCampaignStats extends React.Component {
             <div className={css(styles.rightAlign)}>
               <div className={css(styles.inline)}>
                 <div className={css(styles.inline)}>
-                  {!campaign.isArchived ? (
+                  {
                     // edit
                     <Button
                       {...dataTest("editCampaign")}
@@ -323,7 +323,7 @@ class AdminCampaignStats extends React.Component {
                     >
                       Edit
                     </Button>
-                  ) : null}
+                  }
                   <ScriptPreviewButton campaignId={campaignId} />
 
                   {isAdmin

--- a/src/containers/CampaignList/components/CampaignListRow.tsx
+++ b/src/containers/CampaignList/components/CampaignListRow.tsx
@@ -23,9 +23,6 @@ const useStyles = makeStyles({
     alignItems: "center"
   },
   chip: { margin: "4px" },
-  past: {
-    opacity: 0.6
-  },
   secondaryText: {
     whiteSpace: "pre-wrap"
   }
@@ -55,10 +52,12 @@ export const CampaignListRow: React.FC<Props> = (props) => {
     externalSystem
   } = campaign;
 
-  let listItemStyle = {};
+  let listItemStyle: React.CSSProperties = {};
   let leftIcon;
   if (isArchived) {
-    listItemStyle = styles.past;
+    listItemStyle = {
+      opacity: 0.6
+    };
   } else if (!isStarted || hasUnassignedContacts) {
     listItemStyle = {
       color: theme.palette.warning.dark
@@ -148,6 +147,7 @@ export const CampaignListRow: React.FC<Props> = (props) => {
   const campaignUrl = `/admin/${organizationId}/campaigns/${campaign.id}${
     isStarted ? "" : "/edit"
   }`;
+
   return (
     <ListItem
       {...dataTest("campaignRow", false)}


### PR DESCRIPTION
## Description

This PR:
1. Fixes a bug with `CampaignListRow` styling introduced in #43 
2. Enables showing the Edit button on the `AdminCampaignStats` age regardless of whether the campaign is archived or not

## Motivation and Context

1. Prevented the archived campaign list from loading
2. Address the annoying problem of not being able to access the campaign editor via the UI for an archived campaign, which prevented easily copying scripts etc. from archived campaigns.

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
