### PR TITLE
fix(mms): skip file validation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Hadolint"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: jbergstroem/hadolint-gh-action@v1
         with:
           error_level: 0
@@ -53,9 +53,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: node_modules
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/src/server/api/root-resolvers.ts
+++ b/src/server/api/root-resolvers.ts
@@ -2,7 +2,7 @@ import { ForbiddenError } from "apollo-server-errors";
 import _ from "lodash";
 
 import { config } from "../../config";
-import { VALID_CONTENT_TYPES, withTempDownload } from "../../lib/utils";
+import { withTempDownload } from "../../lib/utils";
 import {
   getInstanceNotifications,
   getOrgLevelNotifications
@@ -14,7 +14,6 @@ import { queryCampaignOverlaps } from "./campaign-overlap";
 import { getConversations } from "./conversations";
 import { accessRequired, authRequired, superAdminRequired } from "./errors";
 import { getStepsToUpdate } from "./lib/bulk-script-editor";
-import { getFileType } from "./lib/file-type";
 import { formatPage } from "./lib/pagination";
 import { getUsers, getUsersById } from "./user";
 
@@ -526,10 +525,13 @@ const rootResolvers = {
       });
     },
     isValidAttachment: async (_root, { fileUrl }, _context) => {
-      const handler = async (filePath) => {
-        const fileType = await getFileType(filePath);
+      // 2025-03-25: @npcz/magic is throwing an uncatachable exception
+      // skip file type validation for now
+      const handler = async (_filePath: string) => {
+        return true;
+        // const fileType = await getFileType(filePath);
 
-        return VALID_CONTENT_TYPES.includes(fileType);
+        // return VALID_CONTENT_TYPES.includes(fileType);
       };
       return withTempDownload(fileUrl, handler);
     }


### PR DESCRIPTION
## Description

This disables MMS file validation temporarily

## Motivation and Context

`@npcz/magic` is throwing an uncatchable exception in dev and in production, whenever an MMS url is used in a script. Until we can investigate further, we should disable MMS file validation, since it's only used for displaying user feedback. This allows users to set up MMS scripts and send MMS while we work on this.

```
{"level":"error","message":"unhandledRejection: Failed to parse URL from /usr/Spoke/node_modules/@npcz/magic/dist/magic-js.wasm","stack":"TypeError: Failed to parse URL from /usr/Spoke/node_modules/@npcz/magic/dist/magic-js.wasm\n    at node:internal/deps/undici/undici:13178:13\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)","timestamp":"2025-03-25T19:01:16.343Z"}
```

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
