### PR TITLE
docs(claude): run prettier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,23 +5,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Common Development Commands
 
 ### Building and Development
+
 - `yarn dev` - Start development server with client and server hot-reloading
 - `yarn build` - Build production bundle (client and server)
 - `yarn start` - Start production server from built files
 - `yarn codegen` - Generate GraphQL types and schema files
 
 ### Testing
+
 - `yarn test` - Run all tests with Jest
 - `yarn test:e2e` - Run end-to-end tests
 - `yarn test:coverage` - Run tests with coverage report
 
 ### Linting and Formatting
+
 - `yarn lint` - Run ESLint on all TypeScript/JavaScript files
 - `yarn lint:fix` - Fix auto-fixable linting issues
 - `yarn format` - Check Prettier formatting
 - `yarn format:fix` - Apply Prettier formatting
 
 ### Database Operations
+
 - `yarn knex migrate:latest` - Run database migrations
 - `yarn migrate:worker` - Run graphile-worker database setup (required once)
 - `yarn knex migrate:make <name>` - Create new migration
@@ -31,6 +35,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Spoke is a full-stack SMS texting platform for political campaigns and advocacy organizations, built with:
 
 ### Core Stack
+
 - **Frontend**: React 17 with Material-UI v4, Apollo Client for GraphQL
 - **Backend**: Node.js with Express, Apollo Server for GraphQL API
 - **Database**: PostgreSQL with Knex.js ORM
@@ -40,6 +45,7 @@ Spoke is a full-stack SMS texting platform for political campaigns and advocacy 
 ### Application Structure
 
 #### Server Architecture (`src/server/`)
+
 - **Entry Point**: `src/server/index.ts` - Main server with Lightship health checks
 - **Server Modes**: Can run as Server, Worker, or Dual mode (both)
 - **GraphQL API**: Apollo Server in `src/server/api/` with schema-first approach
@@ -48,6 +54,7 @@ Spoke is a full-stack SMS texting platform for political campaigns and advocacy 
 - **Authentication**: Passport strategies (Auth0, Slack, Local) in `src/server/auth-passport/`
 
 #### Client Architecture (`src/client/` and `src/containers/`)
+
 - **Routing**: React Router with nested routes in `src/routes.jsx`
 - **State Management**: Apollo Client cache + local component state
 - **UI Components**: Reusable components in `src/components/`
@@ -55,6 +62,7 @@ Spoke is a full-stack SMS texting platform for political campaigns and advocacy 
 - **Internationalization**: i18next with locale files in `public/locales/`
 
 #### Key Container Organization
+
 - **Admin Containers**: Campaign management, user administration, messaging oversight
   - `AdminCampaignEdit/` - Campaign builder with multi-step form sections
   - `AdminIncomingMessageList/` - Message moderation and conversation management
@@ -64,23 +72,27 @@ Spoke is a full-stack SMS texting platform for political campaigns and advocacy 
   - `AssignmentTexterContact/` - Individual contact interaction
 
 ### Database Schema
+
 - Uses Knex migrations in `migrations/` directory
 - Core entities: organizations, campaigns, users, messages, contacts
 - Background job tables managed by Graphile Worker
 - Supports read replicas via `DATABASE_READER_URL`
 
 ### Configuration System
+
 - Environment-based configuration in `src/config.js` using envalid
 - Extensive configuration options for SMS services, authentication, feature flags
 - Client/server config separation with `isClient` flag
 
 ### Development Workflow
+
 1. **Local Setup**: Docker Compose for PostgreSQL (`docker compose up postgres`)
 2. **Database Setup**: Run worker migrations then Knex migrations
 3. **Code Generation**: GraphQL schema and TypeScript types auto-generated
 4. **Development Mode**: Webpack dev server + nodemon for hot reloading
 
 ### Code Conventions (from conventions.md)
+
 - Component props interfaces: `[ComponentName]Props` pattern
 - Use affirmative boolean variables (`showWarning` not `hideWarning`)
 - Avoid unnecessary divs, return `null` instead of empty divs
@@ -89,6 +101,7 @@ Spoke is a full-stack SMS texting platform for political campaigns and advocacy 
 - Styling: Single inline styles max, use `makeStyle` hooks for complex styling
 
 ### Key Features
+
 - **Campaign Management**: Multi-step campaign creation with contact uploads
 - **Message Threading**: Conversation-based texting with escalation support
 - **Assignment System**: Dynamic contact assignment to texters


### PR DESCRIPTION
## Description

This runs `prettier --write` on [`CLAUDE.MD`](https://github.com/With-the-Ranks/Spoke/pull/76/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7)

## Motivation and Context

CI/CD failing after #75 This potentially deserves a more comprehensive defensive fix, like running `prettier --fix` via `lint-staged` against files that aren't fixed directly by eslint but that can maybe be tackled more exhaustively before merging #63

## How Has This Been Tested?

CI/CD now passing