### PR TITLE
fix(texter): render badge buttons

### DIFF
--- a/src/containers/TexterTodoList/components/AssignmentSummary.tsx
+++ b/src/containers/TexterTodoList/components/AssignmentSummary.tsx
@@ -95,6 +95,8 @@ export const AssignmentSummary: React.FC<Props> = (props) => {
 
   const {
     assignment,
+    unmessagedCount,
+    unrepliedCount,
     badTimezoneCount,
     pastMessagesCount,
     skippedMessagesCount
@@ -129,6 +131,26 @@ export const AssignmentSummary: React.FC<Props> = (props) => {
           <div dangerouslySetInnerHTML={{ __html: introHtml || "" }} />
         </div>
         <CardActions className={classes.cardActions}>
+          {renderBadgedButton({
+            dataTestText: "sendFirstTexts",
+            assignment,
+            title: "Send first texts",
+            type: "initial",
+            count: unmessagedCount,
+            primary: true,
+            contactsFilter: "text"
+          })}
+          {renderBadgedButton({
+            dataTestText: "sendReplies",
+            assignment,
+            title: "Send replies",
+            type: "reply",
+            count: unrepliedCount,
+            primary: false,
+            disabled: false,
+            contactsFilter: "reply",
+            hideIfZero: true
+          })}
           {renderBadgedButton({
             assignment,
             title: "Past Messages",


### PR DESCRIPTION
## Description

This restores the rendering of the "send first texts" and "send replies" badge buttons for the texter todos page

## Motivation and Context

Regression introduced in #62 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
