### PR TITLE
fix(texter): hide send first texts when none left

### DIFF
--- a/src/containers/TexterTodoList/components/AssignmentSummary.tsx
+++ b/src/containers/TexterTodoList/components/AssignmentSummary.tsx
@@ -138,7 +138,8 @@ export const AssignmentSummary: React.FC<Props> = (props) => {
             type: "initial",
             count: unmessagedCount,
             primary: true,
-            contactsFilter: "text"
+            contactsFilter: "text",
+            hideIfZero: true
           })}
           {renderBadgedButton({
             dataTestText: "sendReplies",


### PR DESCRIPTION
## Description

This restores hiding the send first texts button when all initials are sent

## Motivation and Context

Follow up to #78 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
