### PR TITLE
fix(autosending): only use active initial script

### DIFF
--- a/src/server/tasks/retry-interaction-step.ts
+++ b/src/server/tasks/retry-interaction-step.ts
@@ -51,6 +51,7 @@ export const retryInteractionStep: Task = async (
       where
         cc.id = $1
         and istep.parent_interaction_id is null
+        and not istep.is_deleted
     `,
     [campaignContactId]
   );


### PR DESCRIPTION
## Description

This prevents autosending from choosing scripts that have been deleted

## Motivation and Context

Bug noticed in production

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
