### PR TITLE
fix(campaign-variable): pass input types for updates

### DIFF
--- a/src/api/campaign-variable.ts
+++ b/src/api/campaign-variable.ts
@@ -1,8 +1,8 @@
 /* eslint-disable import/prefer-default-export */
-import type { CampaignVariable } from "@spoke/spoke-codegen";
+import type { CampaignVariableInput } from "@spoke/spoke-codegen";
 
-export const sortCampaignVariables = (
-  campaignVariables: CampaignVariable[]
+export const sortCampaignVariableInputs = (
+  campaignVariables: CampaignVariableInput[]
 ) => {
   return campaignVariables.sort((cv1, cv2) => {
     if (cv1.displayOrder < cv2.displayOrder) return -1;

--- a/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignVariablesForm.tsx
@@ -18,7 +18,7 @@ import {
 import React, { useCallback, useMemo } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 
-import { sortCampaignVariables } from "../../../api/campaign-variable";
+import { sortCampaignVariableInputs } from "../../../api/campaign-variable";
 import { allScriptFields, VARIABLE_NAME_REGEXP } from "../../../lib/scripts";
 import CampaignFormSectionHeading from "../components/CampaignFormSectionHeading";
 import type { FullComponentProps } from "../components/SectionWrapper";
@@ -78,12 +78,13 @@ const CampaignVariablesForm: React.FC<FullComponentProps> = (props) => {
       const noPrefixCampaignVariables =
         unsortedCampaignVariables?.map((campaignVariable) => {
           return {
-            ...campaignVariable,
-            name: campaignVariable.name.replace("cv:", "")
+            displayOrder: campaignVariable.displayOrder,
+            name: campaignVariable.name.replace("cv:", ""),
+            value: campaignVariable.value
           };
         }) ?? [];
 
-      const campaignVariables = sortCampaignVariables(
+      const campaignVariables = sortCampaignVariableInputs(
         noPrefixCampaignVariables
       );
       // Wait for useForm's subscription to be ready before reset() sends a signal to flush form state update


### PR DESCRIPTION
## Description

This passes the `CampaignVariableInput` type instead of `CampaignVariable` when performing updates to campaign variables

## Motivation and Context

Regression introduced in #15 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
