### PR TITLE
feat(telnyx): add mobiles only error code

### DIFF
--- a/src/lib/telco-error-codes.ts
+++ b/src/lib/telco-error-codes.ts
@@ -10,6 +10,7 @@ export const errorCodeDescriptions: Record<string, string> = {
   "40009": "Invalid body",
   "40011": "Too many messages",
   "40012": "Invalid destination number",
+  "21211": "Invalid destination number",
   "21610": "Recipient unsubscribed",
   "30001": "Queue overflow",
   "30002": "Account suspended",


### PR DESCRIPTION
## Description

This adds a description for error code 21211

## Motivation and Context

Telnyx returns this error code when sending to an invalid phone number with the mobiles only setting See https://github.com/With-the-Ranks/switchboard/pull/10

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
