### PR TITLE
fix(message-review): stop query on initial load

### DIFF
--- a/src/containers/AdminIncomingMessageList/index.tsx
+++ b/src/containers/AdminIncomingMessageList/index.tsx
@@ -8,6 +8,7 @@ import {
   useMegaBulkReassignCampaignContactsMutation,
   useMegaReassignCampaignContactsMutation
 } from "@spoke/spoke-codegen";
+import isEqual from "lodash/isEqual";
 import omit from "lodash/omit";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
@@ -29,7 +30,7 @@ import {
   TagsFilterParam
 } from "./types";
 
-/* Initialized as objects to later facillitate shallow comparison */
+/* Initial filter defaults used for value comparison via isEqual */
 const initialCampaignsFilter = { isArchived: false };
 const initialContactsFilter = { isOptedOut: false };
 const initialAssignmentsFilter = {};
@@ -367,16 +368,16 @@ const AdminIncomingMessageList: React.FC<AdminIncomingMessageListProps> = (
   };
 
   /*
-    Shallow comparison here done intentionally – we want to know if its changed, not if it's different,
-    since we want to allow the user to make the same query as the default one, but we don't want to
-    pre-emptively run the default (and most expensive) one
+    We compare filter values (not references) to check if filters have changed from defaults.
+    This allows users to make the same query as the default, but prevents pre-emptively
+    running the default (and most expensive) query on initial load.
   */
   const haveFiltersChangedFromDefaults = () => {
     return (
-      campaignsFilter !== initialCampaignsFilter ||
-      contactsFilter !== initialContactsFilter ||
-      assignmentsFilter !== initialAssignmentsFilter ||
-      tagsFilter !== initialTagsFilter ||
+      !isEqual(campaignsFilter, initialCampaignsFilter) ||
+      !isEqual(contactsFilter, initialContactsFilter) ||
+      !isEqual(assignmentsFilter, initialAssignmentsFilter) ||
+      !isEqual(tagsFilter, initialTagsFilter) ||
       contactNameFilter !== undefined
     );
   };


### PR DESCRIPTION
## Description

This stops the message review query from running on the initial load of the page

Claude: Replace reference comparison with lodash isEqual for filter comparison. This ensures filters are correctly identified as unchanged on initial load, preventing the expensive default query from running prematurely.

## Motivation and Context

Closes #95 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
