### PR TITLE
chore(crypto): use node v24 supported encryption format

### DIFF
--- a/migrations/20260209061552_encrypt_auth_tokens_with_iv.js
+++ b/migrations/20260209061552_encrypt_auth_tokens_with_iv.js
@@ -26,17 +26,19 @@ function encryptWithIv(value, secret) {
   const key = crypto.createHash("sha256").update(secret).digest();
   const iv = crypto.randomBytes(16);
   const cipher = crypto.createCipheriv(algorithm, key, iv);
+
   let encrypted = cipher.update(value, inputEncoding, outputEncoding);
   encrypted += cipher.final(outputEncoding);
-  return `${iv.toString(outputEncoding)}:${encrypted}`;
+  return `V2:${iv.toString(outputEncoding)}:${encrypted}`;
 }
 
 // New decryption using createDecipheriv (with IV)
 function decryptWithIv(encrypted, secret) {
   const key = crypto.createHash("sha256").update(secret).digest();
   const parts = encrypted.split(":");
-  const iv = Buffer.from(parts[0], outputEncoding);
-  const encryptedData = parts[1];
+  const iv = Buffer.from(parts[1], outputEncoding);
+  const encryptedData = parts[2];
+
   const decipher = crypto.createDecipheriv(algorithm, key, iv);
   let decrypted = decipher.update(encryptedData, outputEncoding, inputEncoding);
   decrypted += decipher.final(inputEncoding);
@@ -54,7 +56,7 @@ exports.up = function up(knex) {
     .whereNot("encrypted_auth_token", "")
     .then((rows) => {
       const updates = rows
-        .filter((row) => !row.encrypted_auth_token.includes(":"))
+        .filter((row) => !row.encrypted_auth_token.startsWith("V2:"))
         .map((row) => {
           const decrypted = legacyDecrypt(
             row.encrypted_auth_token,
@@ -80,7 +82,7 @@ exports.down = function down(knex) {
     .whereNot("encrypted_auth_token", "")
     .then((rows) => {
       const updates = rows
-        .filter((row) => row.encrypted_auth_token.includes(":"))
+        .filter((row) => row.encrypted_auth_token.startsWith("V2:"))
         .map((row) => {
           const decrypted = decryptWithIv(
             row.encrypted_auth_token,

--- a/src/server/api/lib/crypto.js
+++ b/src/server/api/lib/crypto.js
@@ -18,18 +18,19 @@ const symmetricEncrypt = (value) => {
   let encrypted = cipher.update(value, inputEncoding, outputEncoding);
   encrypted += cipher.final(outputEncoding);
 
-  // Prepend IV to encrypted data (IV is not secret)
-  return `${iv.toString(outputEncoding)}:${encrypted}`;
+  // Prepend IV to encrypted data (IV is not secret) and prefix with V2
+  return `V2:${iv.toString(outputEncoding)}:${encrypted}`;
 };
 
 const symmetricDecrypt = (encrypted) => {
+  // parts are V2, iv, and encrypted string
   const parts = encrypted.split(":");
-  if (parts.length !== 2) {
+  if (parts.length !== 3) {
     throw new Error("Invalid encrypted data format");
   }
 
-  const iv = Buffer.from(parts[0], outputEncoding);
-  const encryptedData = parts[1];
+  const iv = Buffer.from(parts[1], outputEncoding);
+  const encryptedData = parts[2];
 
   const decipher = crypto.createDecipheriv(algorithm, key, iv);
   let decrypted = decipher.update(encryptedData, outputEncoding, inputEncoding);


### PR DESCRIPTION
## Description

This PR moves Spoke to the cryptography methods that are supported in node v24

## Motivation and Context

Prep for merging #88 - node v24 [deprecates](https://github.com/nodejs/node/blob/main/doc/api/deprecations.md#dep0106-cryptocreatecipher-and-cryptocreatedecipher) the previous "easier" crypto methods

This PR focuses on `messaging_service.encrypted_auth_token` as the only _stored_ value which is encrypted via the changed functions. 

Note that `campaign.previewUrl` is also [generated](https://github.com/With-the-Ranks/Spoke/blob/main/src/server/api/campaign.js#L728) via the same encryption function. However, since that value isn't stored, we don't need to really worry about a migration for it. Clients who use preview URLs often will notice that the format for the URL (ex. always including a colon), as well as old links, have changed.

## How Has This Been Tested?

This has been tested locally by:
1. Loading in a client session secret to `.env` + adding their messaging service record to the local database
2. Running `dev-tools/symmetric-decrypt.js` with the `encrypted_auth_token` string and storing this (to verify against in step 4)
3. Switching to this branch and running the new migration (to encrypt the token with an iv)
4. Running `dev-tools/symmetric-decrypt.js` with the newly encrypted value to verify that the decrypted string matches the one from step 2

## Release Notes
- #88 must be on a _separate_ release to be rolled out after a release that contains this
- We should create an easy to restore backup of `messaging_service` records, prior to rolling this out, just in case

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
