### PR TITLE
ci(staging): auto-deploy to staging on merge to main

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -18,6 +18,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Prepare tags
       id: tags
       shell: bash

--- a/.github/actions/gcp-auth/action.yml
+++ b/.github/actions/gcp-auth/action.yml
@@ -15,9 +15,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: Authenticate to GCP
       uses: google-github-actions/auth@v2
       with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,8 @@ env:
   GCP_REGION: us-west1
   GAR_REGISTRY: us-west1-docker.pkg.dev/spoke-407503/spoke/core
   GKE_CLUSTER: spoke-cluster
+  STAGING_NAMESPACE: spoke-staging
+  STAGING_DEPLOYMENT: main-spoke
   WIF_PROVIDER: projects/630731592917/locations/global/workloadIdentityPools/github-actions/providers/github
   WIF_SERVICE_ACCOUNT: spoke-ci@spoke-407503.iam.gserviceaccount.com
 
@@ -129,9 +131,9 @@ jobs:
 
       - name: Restart staging deployment
         run: |
-          if kubectl get deployment main-spoke -n spoke-staging &>/dev/null; then
-            kubectl rollout restart deployment/main-spoke -n spoke-staging
-            kubectl rollout status deployment/main-spoke -n spoke-staging --timeout=5m
+          if kubectl get deployment ${{ env.STAGING_DEPLOYMENT }} -n ${{ env.STAGING_NAMESPACE }} &>/dev/null; then
+            kubectl rollout restart deployment/${{ env.STAGING_DEPLOYMENT }} -n ${{ env.STAGING_NAMESPACE }}
+            kubectl rollout status deployment/${{ env.STAGING_DEPLOYMENT }} -n ${{ env.STAGING_NAMESPACE }} --timeout=5m
           else
             echo "Staging deployment not found — skipping restart"
           fi


### PR DESCRIPTION
## Summary

Adds a `deploy-staging` job to the CI/CD pipeline so that every merge to `main` automatically builds, pushes, and deploys to the staging environment. This is a prerequisite for the staging infrastructure defined in [spoke-infra#151](https://github.com/With-the-Ranks/spoke-infra/pull/151).

**Stacked on [#121](https://github.com/With-the-Ranks/Spoke/pull/121)** — which migrates the existing `publish-docker-image` job to Workload Identity Federation. This PR reuses the same WIF auth pattern and `spoke-ci` service account for the staging job.

### What it does

- **Builds the Docker image** after tests pass on `main`
- **Pushes to GAR** with two tags:
  - `core:main-latest` -- mutable tag tracked by the staging Kubernetes Deployment (with `imagePullPolicy: Always`)
  - `core:main-{short-sha}` -- immutable tag for auditability
- **Triggers a rolling restart** of `deployment/main-spoke` in the `spoke-staging` namespace and **waits for the rollout to complete** (`kubectl rollout status --timeout=5m`)

### What it does NOT change

- The existing `publish-docker-image` job (tag-triggered release builds) is unchanged (it was updated in #121)
- No changes to the test job or PR pipeline

### Improvements over the original version of this PR

All review feedback from the AI reviewers has been addressed:

| Feedback | Resolution |
|----------|-----------|
| No rollout verification | Added `kubectl rollout status --timeout=5m` |
| `id-token: write` unused | Now used — WIF requires it |
| `GCR_JSON_KEY` doing double duty | Replaced with WIF + dedicated `spoke-ci` SA (via #121) |
| Hardcoded GCP values | Extracted to top-level `env` block (via #121) |
| Step ordering (auth after push) | Auth now happens before Docker push |
| No job timeout | Added `timeout-minutes: 30` |
| Cache scope collision | Added `scope=staging` (separate from `scope=release`) |
| Action version inconsistency | Both jobs now use v3/v5 (via #121) |

## Prerequisites

Before this workflow can run successfully:

1. **WIF setup** (done): `spoke-ci` SA, Workload Identity Pool, OIDC provider, and repo binding are all provisioned
2. **Staging namespace and deployment**: Must exist in GKE (created by applying spoke-infra PRs [#148](https://github.com/With-the-Ranks/spoke-infra/pull/148) through [#151](https://github.com/With-the-Ranks/spoke-infra/pull/151))
3. **PR #121 must be merged first**: This PR is stacked on top of it

## Test plan

- [x] Verify CI passes on this PR (hadolint + test jobs)
- [x] Merge #121 first, then rebase and merge this PR
- [ ] Verify the `deploy-staging` job runs on the next merge to `main`
- [ ] Confirm `core:main-latest` and `core:main-{sha}` tags appear in GAR
- [ ] Confirm `kubectl rollout status` succeeds in the job logs
- [ ] Hit the staging health endpoint: `curl https://main.staging.spokewtr.com/`

## If things go wrong

| Failure | What happens | Resolution |
|---------|-------------|------------|
| **Docker build fails** | No image pushed, no restart triggered. Main CI shows red but production is unaffected. | Fix the build issue in a follow-up PR. |
| **GAR push fails** | Same as above -- no image, no restart. | Check WIF configuration and `spoke-ci` SA roles. |
| **GKE auth fails** | Image is pushed but rollout restart fails. Staging stays on previous image. | Verify `spoke-ci` has `container.developer` role. |
| **Rollout times out** | Job fails after 5 minutes. Old pods keep serving. | Check pod logs for crash reason. |

> **Note**: This job only affects staging. A failure in `deploy-staging` does not block the existing `publish-docker-image` job (release builds) or affect production in any way.
