### PR TITLE
ci: migrate to Workload Identity Federation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  GAR_REGION: us-west1
+  GCP_REGION: us-west1
   GAR_REGISTRY: us-west1-docker.pkg.dev/spoke-407503/spoke/core
   WIF_PROVIDER: projects/630731592917/locations/global/workloadIdentityPools/github-actions/providers/github
   WIF_SERVICE_ACCOUNT: spoke-ci@spoke-407503.iam.gserviceaccount.com
@@ -117,7 +117,7 @@ jobs:
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
 
       - name: Configure Docker for GAR
-        run: gcloud auth configure-docker ${{ env.GAR_REGION }}-docker.pkg.dev --quiet
+        run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## TL;DR

This is a security upgrade. Google and GitHub both recommend **Workload Identity Federation (WIF)** as the best practice for authenticating GitHub Actions to GCP, replacing long-lived JSON service account keys. WIF uses short-lived, automatically-rotated credentials with no stored secrets — eliminating the risk of leaked static credentials entirely.

Today, our CI authenticates using a long-lived JSON key (`GCR_JSON_KEY`) belonging to the `spoke-iac` Terraform admin account — the same account that can create/destroy all of our infrastructure. If this key leaks (e.g. via a GitHub Actions compromise), an attacker gets full infrastructure admin access, not just the ability to push Docker images. This PR replaces that with WIF, scoped to a dedicated `spoke-ci` service account that can only push images and restart deployments.

## Summary

- Replace `GCR_JSON_KEY` (long-lived JSON key) with Workload Identity Federation (keyless auth)
- Use a dedicated `spoke-ci` service account with only `artifactregistry.writer` + `container.developer` roles (instead of the over-privileged `spoke-iac` admin SA)
- Bump deprecated GitHub Actions: `docker/setup-buildx-action` v1->v3, `docker/build-push-action` v2->v5
- Remove `docker/login-action` entirely — replaced by `gcloud auth configure-docker` after WIF auth
- Replace deprecated `::set-output` syntax with `$GITHUB_OUTPUT`
- Extract hardcoded GCP project/region values to top-level `env` block
- Add `timeout-minutes: 30` to prevent runaway builds
- Add Docker cache `scope=release` to prevent cross-job cache collisions (prep for staging job in #107)

## GCP resources created (outside this PR)

These have already been provisioned via `gcloud` CLI:

1. **Service account**: `spoke-ci@spoke-407503.iam.gserviceaccount.com` with roles:
   - `roles/artifactregistry.writer` — push Docker images to GAR
   - `roles/container.developer` — kubectl rollout restart for staging deployments
2. **Workload Identity Pool**: `github-actions` (global)
3. **OIDC Provider**: `github` — with attribute condition restricting to `With-the-Ranks` GitHub org
4. **SA binding**: Only `With-the-Ranks/Spoke` repo can impersonate `spoke-ci`

## Test plan

**Before merging:**
- [x] Verify CI passes on this PR (hadolint + test jobs — these do not touch GCP)

**After merging (WIF verification):**
- [x] Tag a test release (e.g. `v0.0.1-wif-test`) to trigger `publish-docker-image`
- [x] Verify the job authenticates via WIF and pushes the image to GAR
- [x] Check the image exists: `gcloud artifacts docker images list us-west1-docker.pkg.dev/spoke-407503/spoke/core --filter="tags:0.0.1-wif-test"`
- [x] If successful, delete the test image and tag

**After WIF is verified working:**
- [ ] Remove `GCR_JSON_KEY` from GitHub repo secrets
- [ ] Delete the permanent key from `spoke-iac` SA

## Sequencing

This PR should be merged **before** #107 (staging auto-deploy). Once merged, #107 can rebase and reuse the same WIF auth pattern + top-level env vars for its `deploy-staging` job.
