### PR TITLE
fix: add messaging service to staging seed data

### DIFF
--- a/seeds/staging.js
+++ b/seeds/staging.js
@@ -29,7 +29,8 @@ const TABLES = [
   { file: "05-interaction-steps.csv", table: "interaction_step" },
   { file: "06-assignments.csv", table: "assignment" },
   { file: "07-campaign-contacts.csv", table: "campaign_contact" },
-  { file: "08-messages.csv", table: "message" }
+  { file: "08-messages.csv", table: "message" },
+  { file: "09-messaging-services.csv", table: "messaging_service", skipSequence: true }
 ];
 
 /*
@@ -109,7 +110,8 @@ exports.seed = async function seed(knex) {
      * application-generated rows (via DEFAULT / nextval) don't collide
      * with the seeded data.
      */
-    for (const { table, sequence } of TABLES) {
+    for (const { table, sequence, skipSequence } of TABLES) {
+      if (skipSequence) continue;
       const seqName = sequence || `${table}_id_seq`;
       await client.query(`
         SELECT setval(

--- a/seeds/staging/09-messaging-services.csv
+++ b/seeds/staging/09-messaging-services.csv
@@ -1,0 +1,2 @@
+messaging_service_sid,organization_id,account_sid,encrypted_auth_token,service_type,active,name,is_default
+staging-messaging-service-1,1,staging-account-sid,staging-encrypted-token,assemble-numbers,true,Default Staging Service,true


### PR DESCRIPTION
## Summary
- Campaign creation in staging fails with "No active messaging services found" because the `messaging_service` table has no rows after seeding
- Adds a new `09-messaging-services.csv` seed file with a default active messaging service for org 1
- Updates `seeds/staging.js` to include the new table, with `skipSequence: true` since `messaging_service` uses a text SID primary key (not an auto-increment sequence)

## Test plan
- [ ] Run `yarn knex seed:run --specific=staging.js` against a staging database and verify the `messaging_service` table has one active row
- [ ] Verify campaign creation at https://main.staging.spokewtr.com/admin/1/campaigns no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)