### PR TITLE
ci: point staging deploy to ui-updates branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -89,7 +89,7 @@ jobs:
         run: yarn jest --forceExit --detectOpenHandles src/**/*
 
   deploy-staging:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/ui-updates'
     needs: test
     name: Deploy to Staging
     environment: staging


### PR DESCRIPTION
## Summary
- Temporarily updates the staging deployment trigger from `main` to `ui-updates` branch so we can test UI updates in staging

## Test plan
- [ ] Verify pushes to `ui-updates` trigger the staging deploy job
- [ ] Verify pushes to `main` no longer trigger staging deploy
- [ ] Revert this change once UI updates testing is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)