### PR TITLE
feat: visual refresh Phase 3 — migrate form fields from MUI v0 to v4

### DIFF
--- a/src/components/forms/GSDateField.tsx
+++ b/src/components/forms/GSDateField.tsx
@@ -1,5 +1,4 @@
-import type { DatePickerProps } from "material-ui";
-import { DatePicker } from "material-ui";
+import TextField from "@material-ui/core/TextField";
 import React from "react";
 
 import { DateTime } from "../../lib/datetime";
@@ -13,11 +12,17 @@ interface GSDateFieldProps {
 }
 
 export default class GSDateField extends GSFormField<
-  GSFormFieldProps & DatePickerProps & GSDateFieldProps,
+  GSFormFieldProps & GSDateFieldProps,
   Record<string, unknown>
 > {
-  pickerOnChange(newDate: DateTime): void {
-    const oldDate: DateTime = DateTime.fromISO(this.props.value as string);
+  handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newDateStr = event.target.value;
+    if (!newDateStr) {
+      this.props.onChange(null);
+      return;
+    }
+    const newDate = DateTime.fromISO(newDateStr);
+    const oldDate = DateTime.fromISO(this.props.value as string);
     const newDateWithHMS = oldDate.isValid
       ? newDate.set({
           hour: oldDate.hour,
@@ -26,23 +31,27 @@ export default class GSDateField extends GSFormField<
         })
       : newDate;
     this.props.onChange(newDateWithHMS.isValid ? newDateWithHMS.toISO() : null);
-  }
+  };
 
   render() {
     const parsedPropDate = DateTime.fromISO(this.props.value as string);
+    const dateValue = parsedPropDate.isValid
+      ? parsedPropDate.toFormat("yyyy-MM-dd")
+      : "";
+
     return (
-      <DatePicker
-        value={parsedPropDate.isValid ? parsedPropDate.toJSDate() : undefined}
-        fullWidth={this.props.fullWidth}
-        autoOk={this.props.autoOk}
-        locale={this.props.locale}
-        className={this.props.className}
+      <TextField
+        type="date"
+        label={this.floatingLabelText()}
+        variant="outlined"
+        size="small"
+        fullWidth={this.props.fullWidth !== false}
+        InputLabelProps={{ shrink: true }}
         name={this.props.name}
-        data-test={this.props["data-test"] as Date}
-        floatingLabelText={this.floatingLabelText()}
-        onChange={(_, newDate) => {
-          this.pickerOnChange(DateTime.fromJSDate(newDate));
-        }}
+        className={this.props.className}
+        data-test={this.props["data-test"]}
+        value={dateValue}
+        onChange={this.handleChange}
       />
     );
   }

--- a/src/components/forms/GSDateField.tsx
+++ b/src/components/forms/GSDateField.tsx
@@ -22,7 +22,7 @@ export default class GSDateField extends GSFormField<
       return;
     }
     const newDate = DateTime.fromISO(newDateStr);
-    const oldDate = DateTime.fromISO(this.props.value as string);
+    const oldDate = DateTime.fromISO(this.props.value || "");
     const newDateWithHMS = oldDate.isValid
       ? newDate.set({
           hour: oldDate.hour,

--- a/src/components/forms/GSDateField.tsx
+++ b/src/components/forms/GSDateField.tsx
@@ -1,58 +1,60 @@
 import TextField from "@material-ui/core/TextField";
-import React from "react";
+import React, { useCallback } from "react";
 
 import { DateTime } from "../../lib/datetime";
 import type { ISODateString } from "../../lib/js-types";
 import type { GSFormFieldProps } from "./GSFormField";
-import { GSFormField } from "./GSFormField";
+import { floatingLabelText } from "./GSFormField";
 
-interface GSDateFieldProps {
+interface GSDateFieldProps extends GSFormFieldProps {
   onChange: (d: ISODateString | null) => void;
   value: string | undefined;
+  fullWidth?: boolean;
 }
 
-export default class GSDateField extends GSFormField<
-  GSFormFieldProps & GSDateFieldProps,
-  Record<string, unknown>
-> {
-  handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newDateStr = event.target.value;
-    if (!newDateStr) {
-      this.props.onChange(null);
-      return;
-    }
-    const newDate = DateTime.fromISO(newDateStr);
-    const oldDate = DateTime.fromISO(this.props.value || "");
-    const newDateWithHMS = oldDate.isValid
-      ? newDate.set({
-          hour: oldDate.hour,
-          minute: oldDate.minute,
-          second: oldDate.second
-        })
-      : newDate;
-    this.props.onChange(newDateWithHMS.isValid ? newDateWithHMS.toISO() : null);
-  };
+const GSDateField: React.FC<GSDateFieldProps> = (props) => {
+  const { value, onChange, name, className, fullWidth } = props;
 
-  render() {
-    const parsedPropDate = DateTime.fromISO(this.props.value as string);
-    const dateValue = parsedPropDate.isValid
-      ? parsedPropDate.toFormat("yyyy-MM-dd")
-      : "";
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newDateStr = event.target.value;
+      if (!newDateStr) {
+        onChange(null);
+        return;
+      }
+      const newDate = DateTime.fromISO(newDateStr);
+      const oldDate = DateTime.fromISO(value || "");
+      const newDateWithHMS = oldDate.isValid
+        ? newDate.set({
+            hour: oldDate.hour,
+            minute: oldDate.minute,
+            second: oldDate.second
+          })
+        : newDate;
+      onChange(newDateWithHMS.isValid ? newDateWithHMS.toISO() : null);
+    },
+    [value, onChange]
+  );
 
-    return (
-      <TextField
-        type="date"
-        label={this.floatingLabelText()}
-        variant="outlined"
-        size="small"
-        fullWidth={this.props.fullWidth !== false}
-        InputLabelProps={{ shrink: true }}
-        name={this.props.name}
-        className={this.props.className}
-        data-test={this.props["data-test"]}
-        value={dateValue}
-        onChange={this.handleChange}
-      />
-    );
-  }
-}
+  const parsedPropDate = DateTime.fromISO(value as string);
+  const dateValue = parsedPropDate.isValid
+    ? parsedPropDate.toFormat("yyyy-MM-dd")
+    : "";
+
+  return (
+    <TextField
+      type="date"
+      label={floatingLabelText(props)}
+      variant="outlined"
+      size="small"
+      fullWidth={fullWidth}
+      InputLabelProps={{ shrink: true }}
+      name={name}
+      className={className}
+      value={dateValue}
+      onChange={handleChange}
+    />
+  );
+};
+
+export default GSDateField;

--- a/src/components/forms/GSFormField.tsx
+++ b/src/components/forms/GSFormField.tsx
@@ -9,15 +9,21 @@ export interface GSFormFieldProps extends FieldProps {
   ["data-test"]?: any;
 }
 
+/** Standalone helper – usable from functional components */
+export const floatingLabelText = (
+  props: Pick<GSFormFieldProps, "floatingLabelText" | "label">
+) =>
+  props.floatingLabelText === false
+    ? null
+    : props.floatingLabelText || props.label;
+
 export class GSFormField<P extends GSFormFieldProps, S> extends Component<
   P,
   S
 > {
   // eslint-disable-next-line react/no-unused-class-component-methods
   floatingLabelText() {
-    return this.props.floatingLabelText === false
-      ? null
-      : this.props.floatingLabelText || this.props.label;
+    return floatingLabelText(this.props);
   }
 }
 

--- a/src/components/forms/GSPasswordField.jsx
+++ b/src/components/forms/GSPasswordField.jsx
@@ -2,7 +2,7 @@ import TextField from "@material-ui/core/TextField";
 import omit from "lodash/omit";
 import React from "react";
 
-import GSFormField from "./GSFormField";
+import { floatingLabelText } from "./GSFormField";
 
 const V0_PROPS = [
   "errors",
@@ -15,26 +15,26 @@ const V0_PROPS = [
   "underlineFocusStyle"
 ];
 
-export default class GSPasswordField extends GSFormField {
-  render() {
-    const { value } = this.props;
-    const safeProps = omit(this.props, V0_PROPS);
-    return (
-      <TextField
-        {...safeProps}
-        label={this.floatingLabelText()}
-        placeholder={this.props.hintText || undefined}
-        variant="outlined"
-        size="small"
-        fullWidth={this.props.fullWidth !== false}
-        InputLabelProps={{ shrink: true }}
-        onFocus={(event) => event.target.select()}
-        value={value}
-        onChange={(event) => {
-          this.props.onChange(event.target.value);
-        }}
-        type="password"
-      />
-    );
-  }
-}
+const GSPasswordField = (props) => {
+  const { value, onChange, hintText, fullWidth } = props;
+  const safeProps = omit(props, V0_PROPS);
+  return (
+    <TextField
+      {...safeProps}
+      label={floatingLabelText(props)}
+      placeholder={hintText || undefined}
+      variant="outlined"
+      size="small"
+      fullWidth={fullWidth}
+      InputLabelProps={{ shrink: true }}
+      onFocus={(event) => event.target.select()}
+      value={value}
+      onChange={(event) => {
+        onChange(event.target.value);
+      }}
+      type="password"
+    />
+  );
+};
+
+export default GSPasswordField;

--- a/src/components/forms/GSPasswordField.jsx
+++ b/src/components/forms/GSPasswordField.jsx
@@ -1,19 +1,34 @@
-import TextField from "material-ui/TextField";
+import TextField from "@material-ui/core/TextField";
+import omit from "lodash/omit";
 import React from "react";
 
 import GSFormField from "./GSFormField";
 
+const V0_PROPS = [
+  "errors",
+  "floatingLabelText",
+  "floatingLabelStyle",
+  "fullWidth",
+  "hintText",
+  "errorText",
+  "underlineShow",
+  "underlineFocusStyle"
+];
+
 export default class GSPasswordField extends GSFormField {
   render() {
     const { value } = this.props;
+    const safeProps = omit(this.props, V0_PROPS);
     return (
       <TextField
-        floatingLabelText={this.floatingLabelText()}
-        floatingLabelStyle={{
-          zIndex: 0
-        }}
+        {...safeProps}
+        label={this.floatingLabelText()}
+        placeholder={this.props.hintText || undefined}
+        variant="outlined"
+        size="small"
+        fullWidth={this.props.fullWidth !== false}
+        InputLabelProps={{ shrink: true }}
         onFocus={(event) => event.target.select()}
-        {...this.props}
         value={value}
         onChange={(event) => {
           this.props.onChange(event.target.value);

--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -166,7 +166,7 @@ class GSScriptField extends GSFormField {
           multiline
           variant="outlined"
           size="small"
-          fullWidth={this.props.fullWidth !== false}
+          fullWidth={this.props.fullWidth}
           InputLabelProps={{ shrink: true }}
           placeholder={this.props.hintText || undefined}
           onClick={this.handleOpenDialog}

--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -2,8 +2,8 @@ import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
+import TextField from "@material-ui/core/TextField";
 import pick from "lodash/pick";
-import TextField from "material-ui/TextField";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -153,10 +153,6 @@ class GSScriptField extends GSFormField {
     // The "errors" prop is an empty object and is not mentioned in yum or react-formal documentation
     const passThroughProps = pick(this.props, [
       "className",
-      "fullWidth",
-      "hintText",
-      "label",
-      "multiLine",
       "name",
       "value",
       "data-test",
@@ -166,13 +162,15 @@ class GSScriptField extends GSFormField {
     return (
       <div>
         <TextField
-          multiLine
-          onClick={this.handleOpenDialog}
-          floatingLabelText={this.floatingLabelText()}
-          floatingLabelStyle={{
-            zIndex: 0
-          }}
           {...passThroughProps}
+          multiline
+          variant="outlined"
+          size="small"
+          fullWidth={this.props.fullWidth !== false}
+          InputLabelProps={{ shrink: true }}
+          placeholder={this.props.hintText || undefined}
+          onClick={this.handleOpenDialog}
+          label={this.floatingLabelText()}
         />
         {this.renderDialog()}
       </div>

--- a/src/components/forms/GSSelectField.jsx
+++ b/src/components/forms/GSSelectField.jsx
@@ -22,7 +22,7 @@ export default class GSSelectField extends GSFormField {
       <FormControl
         variant="outlined"
         size="small"
-        fullWidth={this.props.fullWidth !== false}
+        fullWidth={this.props.fullWidth}
       >
         {label && (
           <InputLabel id={labelId} shrink>

--- a/src/components/forms/GSSelectField.jsx
+++ b/src/components/forms/GSSelectField.jsx
@@ -1,5 +1,7 @@
-import { MenuItem } from "material-ui/Menu";
-import SelectField from "material-ui/SelectField";
+import FormControl from "@material-ui/core/FormControl";
+import InputLabel from "@material-ui/core/InputLabel";
+import MenuItem from "@material-ui/core/MenuItem";
+import Select from "@material-ui/core/Select";
 import React from "react";
 
 import GSFormField from "./GSFormField";
@@ -7,21 +9,37 @@ import GSFormField from "./GSFormField";
 export default class GSSelectField extends GSFormField {
   createMenuItems() {
     return this.props.choices.map(({ value, label }) => (
-      <MenuItem value={value} key={value} primaryText={label} />
+      <MenuItem value={value} key={value}>
+        {label}
+      </MenuItem>
     ));
   }
 
   render() {
+    const { label } = this.props;
+    const labelId = `gs-select-${this.props.name || "field"}-label`;
     return (
-      <SelectField
-        floatingLabelText={this.props.label}
-        {...this.props}
-        onChange={(event, index, value) => {
-          this.props.onChange(value);
-        }}
+      <FormControl
+        variant="outlined"
+        size="small"
+        fullWidth={this.props.fullWidth !== false}
       >
-        {this.createMenuItems()}
-      </SelectField>
+        {label && (
+          <InputLabel id={labelId} shrink>
+            {label}
+          </InputLabel>
+        )}
+        <Select
+          labelId={labelId}
+          label={label}
+          value={this.props.value || ""}
+          onChange={(event) => {
+            this.props.onChange(event.target.value);
+          }}
+        >
+          {this.createMenuItems()}
+        </Select>
+      </FormControl>
     );
   }
 }

--- a/src/components/forms/GSTextField.jsx
+++ b/src/components/forms/GSTextField.jsx
@@ -32,7 +32,7 @@ export default class GSTextField extends GSFormField {
         placeholder={this.props.hintText || undefined}
         variant="outlined"
         size="small"
-        fullWidth={this.props.fullWidth !== false}
+        fullWidth={this.props.fullWidth}
         InputLabelProps={{ shrink: true }}
         onFocus={(event) => event.target.select()}
         value={value || ""}

--- a/src/components/forms/GSTextField.jsx
+++ b/src/components/forms/GSTextField.jsx
@@ -1,8 +1,20 @@
+import TextField from "@material-ui/core/TextField";
 import omit from "lodash/omit";
-import TextField from "material-ui/TextField";
 import React from "react";
 
 import GSFormField from "./GSFormField";
+
+// Props from MUI v0 or react-formal that should not be passed to MUI v4 TextField
+const V0_PROPS = [
+  "errors",
+  "floatingLabelText",
+  "floatingLabelStyle",
+  "fullWidth",
+  "hintText",
+  "errorText",
+  "underlineShow",
+  "underlineFocusStyle"
+];
 
 export default class GSTextField extends GSFormField {
   handleNewRef = (el) => {
@@ -11,16 +23,18 @@ export default class GSTextField extends GSFormField {
 
   render() {
     const { value } = this.props;
-    const safeProps = omit(this.props, "errors");
+    const safeProps = omit(this.props, V0_PROPS);
     return (
       <TextField
         ref={this.handleNewRef}
-        floatingLabelText={this.floatingLabelText()}
-        floatingLabelStyle={{
-          zIndex: 0
-        }}
-        onFocus={(event) => event.target.select()}
         {...safeProps}
+        label={this.floatingLabelText()}
+        placeholder={this.props.hintText || undefined}
+        variant="outlined"
+        size="small"
+        fullWidth={this.props.fullWidth !== false}
+        InputLabelProps={{ shrink: true }}
+        onFocus={(event) => event.target.select()}
         value={value || ""}
         onChange={(event) => {
           this.props.onChange(event.target.value);

--- a/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
+++ b/src/containers/AdminCampaignEdit/components/SectionWrapper.tsx
@@ -89,11 +89,11 @@ const useStyles = makeStyles((theme) => ({
   },
   done: {
     backgroundColor: theme.palette.getContrastText(theme.palette.primary.main),
-    color: theme.palette.primary.main
+    color: theme.palette.text.primary
   },
   notDone: {
     backgroundColor: theme.palette.warning.main,
-    color: theme.palette.text.primary
+    color: "#fff"
   },
   cardAvatar: {
     backgroundColor: assemblePalette.common.lightGrey,
@@ -121,7 +121,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.getContrastText(theme.palette.primary.main)
   },
   expandClosedText: {
-    color: theme.palette.primary.main
+    color: theme.palette.text.primary
   }
 }));
 

--- a/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignBasicsForm.tsx
@@ -146,24 +146,26 @@ class CampaignBasicsForm extends React.Component<
             hintText="Get out the vote"
             fullWidth
           />
-          <div style={{ display: "inline-block", width: 256 }}>
-            <SpokeFormField
-              {...dataTest("dueBy")}
-              name="dueBy"
-              label="Due date"
-              type="date"
-              locale="en-US"
-              shouldDisableDate={(date: Date) =>
-                DateTime.fromJSDate(date) < DateTime.local()
-              }
-              autoOk
-            />
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <div style={{ width: 256 }}>
+              <SpokeFormField
+                {...dataTest("dueBy")}
+                name="dueBy"
+                label="Due date"
+                type="date"
+                locale="en-US"
+                shouldDisableDate={(date: Date) =>
+                  DateTime.fromJSDate(date) < DateTime.local()
+                }
+                autoOk
+              />
+            </div>
+            <Tooltip title="Delete the Due Date" placement="top">
+              <IconButton onClick={this.deleteDueDate} style={{ width: 50 }}>
+                <DeleteIcon />
+              </IconButton>
+            </Tooltip>
           </div>
-          <Tooltip title="Delete the Due Date" placement="top">
-            <IconButton onClick={this.deleteDueDate} style={{ width: 50 }}>
-              <DeleteIcon />
-            </IconButton>
-          </Tooltip>
 
           <SpokeFormField
             name="introHtml"


### PR DESCRIPTION
## Summary

- Migrates core form field components from legacy MUI v0 (`material-ui`) to MUI v4 (`@material-ui/core`)
- All fields now use `variant="outlined"` and `size="small"` for a consistent, modern look
- Components updated: `GSTextField`, `GSPasswordField`, `GSSelectField`, `GSDateField`, `GSScriptField`
- Additional containers migrated: `TexterRequest`, `EditName`, `SuperAdminLogin`, `OperationDialog`, `AdminTeamEditor`, `AddDomainDialog`, `DisplayLink`, `NameSearchBar`, `AdminExternalSystems`, `CampaignOverlapManager`, `ContactsSqlForm`, `CampaignAutoassignModeForm`
- Update default colors in SectionWrapper

## Test plan

- [ ] Verify all form fields render with outlined variant across campaign creation flow
- [ ] Check text inputs, password fields, selects, date pickers, and script fields
- [ ] Confirm no regressions in form validation or submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)