### PR TITLE
chore: remove obsolete Claudia Deploy and nyc entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,14 +22,6 @@ test.sqlite
 ### Build Artifacts ###
 /build
 
-### Claudia Deploy ###
-claudia.json
-production-env.json
-stage.json
-beta.json
-stage-env.json
-beta-env.json
-
 # Created by https://www.gitignore.io/api/node,linux,macos,windows
 # Edit at https://www.gitignore.io/?templates=node,linux,macos,windows
 
@@ -99,9 +91,6 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
-
-# nyc test coverage
-.nyc_output
 
 # Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt


### PR DESCRIPTION
## Summary
- Remove the `### Claudia Deploy ###` section (claudia.json, production-env.json, stage/beta env files) — Claudia tooling is no longer used in this project
- Remove `.nyc_output` — nyc coverage is not used in the current test setup

## Test plan
- [ ] Verify `.gitignore` no longer suppresses any files that should be tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)