### PR TITLE
feat: visual refresh Phase 4 — button, card, and component polish

### DIFF
--- a/src/components/BadgePlusIcon.tsx
+++ b/src/components/BadgePlusIcon.tsx
@@ -1,0 +1,38 @@
+import type { SvgIconProps } from "@material-ui/core/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
+import React from "react";
+
+const BadgePlusIcon: React.FC<SvgIconProps> = (props) => (
+  <SvgIcon {...props} viewBox="0 0 24 24">
+    <path
+      d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="12"
+      x2="12"
+      y1="8"
+      y2="16"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <line
+      x1="8"
+      x2="16"
+      y1="12"
+      y2="12"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </SvgIcon>
+);
+
+export default BadgePlusIcon;

--- a/src/components/ScriptPreviewButton.tsx
+++ b/src/components/ScriptPreviewButton.tsx
@@ -31,7 +31,7 @@ export const ScriptPreviewButton: React.FC<ScriptPreviewButtonProps> = (
     <Tooltip title="View an outline of your script" placement="top">
       <Button
         key="open-script-preview"
-        variant="contained"
+        variant="outlined"
         onClick={() => {
           window.open(`/preview/${previewUrl}`, "_blank");
         }}

--- a/src/containers/AdminBulkScriptEditor/index.tsx
+++ b/src/containers/AdminBulkScriptEditor/index.tsx
@@ -203,7 +203,7 @@ const AdminBulkScriptEditor: React.FC = (props) => {
   return (
     <div>
       <h1>Bulk Script Editor</h1>
-      <Paper style={styles.paddedPaper}>
+      <Paper variant="outlined" style={styles.paddedPaper}>
         <p style={{ fontSize: "1.3em" }}>Find and replace</p>
         <TextField
           label="Replace this text..."
@@ -236,7 +236,7 @@ const AdminBulkScriptEditor: React.FC = (props) => {
           <span style={styles.code}>’</span>
         </p>
       </Paper>
-      <Paper style={styles.paddedPaper}>
+      <Paper variant="outlined" style={styles.paddedPaper}>
         <p style={{ fontSize: "1.3em" }}>Filter campaigns</p>
         <FormControlLabel
           label="Include archived campaigns? "

--- a/src/containers/AdminCampaignEdit/index.jsx
+++ b/src/containers/AdminCampaignEdit/index.jsx
@@ -790,10 +790,10 @@ class AdminCampaignEdit extends React.Component {
             : "You need to complete all the sections below before you can start this campaign"}
           {this.renderCurrentEditors()}
         </div>
-        <div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
           {this.props.campaignData.campaign.isArchived ? (
             <Button
-              variant="contained"
+              variant="outlined"
               onClick={() =>
                 this.props.mutations.unarchiveCampaign(
                   this.props.campaignData.campaign.id
@@ -804,7 +804,7 @@ class AdminCampaignEdit extends React.Component {
             </Button>
           ) : (
             <Button
-              variant="contained"
+              variant="outlined"
               onClick={() =>
                 this.props.mutations.archiveCampaign(
                   this.props.campaignData.campaign.id

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -24,6 +24,7 @@ import React from "react";
 import { withRouter } from "react-router-dom";
 import { compose } from "recompose";
 
+import BadgePlusIcon from "../components/BadgePlusIcon";
 import CreateCampaignFromTemplateDialog from "../components/CreateCampaignFromTemplateDialog";
 import LoadingIndicator from "../components/LoadingIndicator";
 import theme from "../styles/theme";
@@ -380,14 +381,21 @@ class AdminCampaignList extends React.Component {
                   <Box
                     sx={{
                       display: "flex",
-                      alignContent: "center",
-                      justifyContent: "center"
+                      alignItems: "center",
+                      justifyContent: "center",
+                      gap: 6
                     }}
                   >
-                    <SpeedDialIcon />
-                    <Typography variant="button">
-                      {" "}
-                      Create a campaign{" "}
+                    <BadgePlusIcon style={{ width: 20, height: 20 }} />
+                    <Typography
+                      variant="button"
+                      style={{
+                        fontWeight: 700,
+                        fontSize: "0.875rem",
+                        textTransform: "none"
+                      }}
+                    >
+                      Create a campaign
                     </Typography>
                   </Box>
                 }
@@ -395,7 +403,7 @@ class AdminCampaignList extends React.Component {
                   <Box
                     sx={{
                       display: "flex",
-                      alignContent: "center",
+                      alignItems: "center",
                       justifyContent: "center"
                     }}
                   >

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -68,9 +68,10 @@ const styles = StyleSheet.create({
     marginRight: 0
   },
   inline: {
-    display: "inline-block",
-    marginLeft: 20,
-    verticalAlign: "middle"
+    display: "inline-flex",
+    flexWrap: "nowrap",
+    gap: 8,
+    alignItems: "center"
   },
   secondaryHeader: {
     ...theme.text.secondaryHeader
@@ -319,6 +320,7 @@ class AdminCampaignStats extends React.Component {
                     <Button
                       {...dataTest("editCampaign")}
                       variant="contained"
+                      color="primary"
                       onClick={this.handleNavigateToEdit}
                     >
                       Edit
@@ -332,7 +334,7 @@ class AdminCampaignStats extends React.Component {
                         // export
                         <Button
                           key="export"
-                          variant="contained"
+                          variant="outlined"
                           disabled={shouldDisableExport}
                           onClick={this.handleOnClickExport}
                         >
@@ -341,7 +343,7 @@ class AdminCampaignStats extends React.Component {
                         // Export for VAN
                         <Button
                           key="van-export"
-                          variant="contained"
+                          variant="outlined"
                           disabled={isVanExportDisabled}
                           onClick={this.handleOnClickVanExport}
                         >
@@ -350,7 +352,7 @@ class AdminCampaignStats extends React.Component {
                         // Sync to VAN
                         <Button
                           key="van-sync"
-                          variant="contained"
+                          variant="outlined"
                           disabled={isVanSyncDisabled}
                           onClick={this.handleOnClickVanSync}
                         >
@@ -360,7 +362,7 @@ class AdminCampaignStats extends React.Component {
                         campaign.isArchived ? (
                           <Button
                             key="unarchive"
-                            variant="contained"
+                            variant="outlined"
                             onClick={() =>
                               this.props.mutations.unarchiveCampaign()
                             }
@@ -371,7 +373,7 @@ class AdminCampaignStats extends React.Component {
                         !campaign.isArchived ? (
                           <Button
                             key="archive"
-                            variant="contained"
+                            variant="outlined"
                             onClick={() =>
                               this.props.mutations.archiveCampaign()
                             }
@@ -383,7 +385,7 @@ class AdminCampaignStats extends React.Component {
                         <Button
                           key="copy"
                           {...dataTest("copyCampaign")}
-                          variant="contained"
+                          variant="outlined"
                           disabled={this.state.copyingCampaign}
                           onClick={
                             onlyCopyCampaignSameOrg

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -84,6 +84,7 @@ const ConversationPreviewModal: React.FC<ConversationPreviewModalProps> = (
 
   return (
     <Paper
+      variant="outlined"
       style={{
         display: "flex",
         flexDirection: "column",

--- a/src/containers/AdminOptOutList/index.tsx
+++ b/src/containers/AdminOptOutList/index.tsx
@@ -189,7 +189,7 @@ const AdminOptOutList: React.FC = (props) => {
           </ButtonGroup>
         </CardContent>
       </Card>
-      <Paper>
+      <Paper variant="outlined">
         <DataGridPro
           autoHeight
           pagination

--- a/src/containers/AdminTagEditor/components/TagEditorList.tsx
+++ b/src/containers/AdminTagEditor/components/TagEditorList.tsx
@@ -45,7 +45,7 @@ const TagEditorList: React.FC<TagEditorListProps> = ({
   return (
     <div style={styles.wrapper}>
       {tags.map((tag) => (
-        <Paper key={tag.id} style={styles.card}>
+        <Paper key={tag.id} variant="outlined" style={styles.card}>
           <div style={{ display: "flex" }}>
             <Chip
               label={tag.title}

--- a/src/containers/AdminTagEditor/index.jsx
+++ b/src/containers/AdminTagEditor/index.jsx
@@ -6,10 +6,10 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import Fab from "@material-ui/core/Fab";
+import TextField from "@material-ui/core/TextField";
 import AddIcon from "@material-ui/icons/Add";
 import pick from "lodash/pick";
 import ColorPicker from "material-ui-color-picker";
-import TextField from "material-ui/TextField";
 import Toggle from "material-ui/Toggle";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
@@ -100,7 +100,11 @@ class AdminTagEditor extends Component {
 
   createTagEditorHandle = (event, value) => {
     let { editingTag } = this.state;
-    editingTag = Object.assign(editingTag, { [event.target.name]: value });
+    // v4 TextField passes value in event.target.value; v0 Toggle passes it as 2nd arg
+    const newValue = value !== undefined ? value : event.target.value;
+    editingTag = Object.assign(editingTag, {
+      [event.target.name]: newValue
+    });
     this.setState({ editingTag });
   };
 
@@ -216,17 +220,30 @@ class AdminTagEditor extends Component {
               <DialogTitle>{`${tagVerb} Tag`}</DialogTitle>
               <DialogContent>
                 <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "row",
-                    justifyContent: "space-between"
-                  }}
+                  style={{ display: "flex", flexDirection: "column", gap: 16 }}
                 >
-                  <div>
+                  {/* Row 1: Tag title */}
+                  <TextField
+                    name="title"
+                    label="Tag title"
+                    variant="outlined"
+                    size="small"
+                    fullWidth
+                    InputLabelProps={{ shrink: true }}
+                    value={editingTag.title || ""}
+                    onChange={this.createTagEditorHandle}
+                  />
+                  {/* Row 2: Tag description | Tag script */}
+                  <div style={{ display: "flex", gap: 16 }}>
                     <TextField
-                      name="title"
-                      floatingLabelText="Tag title"
-                      value={editingTag.title || ""}
+                      name="description"
+                      label="Tag description"
+                      variant="outlined"
+                      size="small"
+                      fullWidth
+                      multiline
+                      InputLabelProps={{ shrink: true }}
+                      value={editingTag.description || ""}
                       onChange={this.createTagEditorHandle}
                     />
                     <GSScriptField
@@ -236,41 +253,58 @@ class AdminTagEditor extends Component {
                       customFields={customFields}
                       campaignVariables={campaignVariables}
                       integrationSourced={integrationSourced}
+                      fullWidth
                       value={editingTag.onApplyScript || ""}
                       onChange={this.handleEditTagScript}
                       onClick={this.handleOpenScriptEditor}
                     />
-                    <br />
-                    <Toggle
-                      name="isAssignable"
-                      label="Allow assignment?"
-                      toggled={editingTag.isAssignable}
-                      onToggle={this.createTagEditorHandle}
-                    />
                   </div>
-                  <div>
-                    <TextField
-                      name="description"
-                      floatingLabelText="Tag description"
-                      multiLine
-                      value={editingTag.description || ""}
-                      onChange={this.createTagEditorHandle}
-                    />
-                    <ColorPicker
-                      name="Text Color"
-                      floatingLabelText="Text color"
-                      defaultValue={editingTag.textColor}
-                      value={editingTag.textColor || ""}
-                      onChange={this.handleEditTextColor}
-                    />
-                    <ColorPicker
-                      name="Background Color"
-                      floatingLabelText="Background color"
-                      defaultValue={editingTag.backgroundColor}
-                      value={editingTag.backgroundColor || ""}
-                      onChange={this.handleEditBackgroundColor}
-                    />
+                  {/* Row 3: Text color | Background color */}
+                  <div style={{ display: "flex", gap: 16 }}>
+                    <div style={{ flex: 1 }}>
+                      <div
+                        style={{
+                          fontSize: 12,
+                          color: "#374151",
+                          marginBottom: 4,
+                          fontWeight: 500
+                        }}
+                      >
+                        Text color
+                      </div>
+                      <ColorPicker
+                        name="Text Color"
+                        defaultValue={editingTag.textColor}
+                        value={editingTag.textColor || ""}
+                        onChange={this.handleEditTextColor}
+                      />
+                    </div>
+                    <div style={{ flex: 1 }}>
+                      <div
+                        style={{
+                          fontSize: 12,
+                          color: "#374151",
+                          marginBottom: 4,
+                          fontWeight: 500
+                        }}
+                      >
+                        Background color
+                      </div>
+                      <ColorPicker
+                        name="Background Color"
+                        defaultValue={editingTag.backgroundColor}
+                        value={editingTag.backgroundColor || ""}
+                        onChange={this.handleEditBackgroundColor}
+                      />
+                    </div>
                   </div>
+                  {/* Row 4: Allow assignment toggle */}
+                  <Toggle
+                    name="isAssignable"
+                    label="Allow assignment?"
+                    toggled={editingTag.isAssignable}
+                    onToggle={this.createTagEditorHandle}
+                  />
                 </div>
                 <div style={{ display: "flex", alignItems: "center" }}>
                   <span>
@@ -287,11 +321,14 @@ class AdminTagEditor extends Component {
                 </div>
                 <TextField
                   name="webhookUrl"
-                  floatingLabelText="Webhook url"
-                  hintText="If set, a request will be sent to this URL whenever this tag is applied."
+                  label="Webhook url"
+                  placeholder="If set, a request will be sent to this URL whenever this tag is applied."
+                  variant="outlined"
+                  size="small"
+                  fullWidth
+                  InputLabelProps={{ shrink: true }}
                   value={editingTag.webhookUrl || ""}
                   onChange={this.createTagEditorHandle}
-                  fullWidth
                 />
               </DialogContent>
               <DialogActions>{actions}</DialogActions>

--- a/src/containers/AdminTrollAlarms/index.tsx
+++ b/src/containers/AdminTrollAlarms/index.tsx
@@ -181,7 +181,7 @@ const AdminTrollAlarms: React.FC<Props> = (props) => {
 
   return (
     <div>
-      <Paper style={styles.controlsContainer}>
+      <Paper variant="outlined" style={styles.controlsContainer}>
         <AutoComplete
           floatingLabelText="Token"
           hintText="Search for a trigger token"

--- a/src/containers/Home/components/OrganizationList.tsx
+++ b/src/containers/Home/components/OrganizationList.tsx
@@ -101,7 +101,10 @@ export const OrganizationList: React.FC = () => {
           mailbox icon.
         </p>
       )}
-      <Paper style={{ margin: "15px auto", maxWidth: "450px" }}>
+      <Paper
+        variant="outlined"
+        style={{ margin: "15px auto", maxWidth: "450px" }}
+      >
         <List>
           {sortedList.map(({ membership, hasAssignments }) => {
             const leftIcon = showIcons ? (

--- a/src/containers/SuperAdminOrganizations.tsx
+++ b/src/containers/SuperAdminOrganizations.tsx
@@ -159,7 +159,7 @@ const SuperAdminOrganizations: React.FC = (_props) => {
   }
   return (
     <div>
-      <Paper>
+      <Paper variant="outlined">
         <DataGridPro
           disableSelectionOnClick
           autoHeight

--- a/src/containers/SuperAdminSuperAdmin/index.tsx
+++ b/src/containers/SuperAdminSuperAdmin/index.tsx
@@ -130,7 +130,7 @@ const SuperAdminSuperAdmin: React.FC = (_props) => {
   }
   return (
     <div>
-      <Paper>
+      <Paper variant="outlined">
         <DataGridPro
           autoHeight
           columns={columns}

--- a/src/containers/Terms.tsx
+++ b/src/containers/Terms.tsx
@@ -75,7 +75,7 @@ const Terms: React.FC = () => {
 
   return (
     <div style={{ maxWidth: 380, maxHeight: 400, margin: "auto" }}>
-      <Paper style={{ padding: 20, margin: 20 }}>
+      <Paper variant="outlined" style={{ padding: 20, margin: 20 }}>
         <h2>Code Of Conduct</h2>
         <Divider />
         <Stepper activeStep={stepIndex} orientation="vertical">

--- a/src/containers/TexterTodoList/components/TexterRequest.jsx
+++ b/src/containers/TexterTodoList/components/TexterRequest.jsx
@@ -124,7 +124,7 @@ class TexterRequest extends React.Component {
       const { amount } = this.props.data.currentUser.currentRequest;
 
       return (
-        <Paper>
+        <Paper variant="outlined">
           <div style={{ padding: "20px" }}>
             <h3> You currently have a pending request</h3>
             <p>
@@ -141,7 +141,7 @@ class TexterRequest extends React.Component {
       settings.showDoNotAssignMessage
     ) {
       return (
-        <Paper>
+        <Paper variant="outlined">
           <div style={{ padding: "20px" }}>
             <h3>Assignment Request Disabled</h3>
             <p>{settings.doNotAssignMessage}</p>
@@ -152,7 +152,7 @@ class TexterRequest extends React.Component {
 
     if (!textsAvailable) {
       return (
-        <Paper>
+        <Paper variant="outlined">
           <div style={{ padding: "20px" }}>
             <h3> No texts available right now </h3>
             <p> Watch out for an announcement when new texts are available! </p>

--- a/src/styles/mui-theme.ts
+++ b/src/styles/mui-theme.ts
@@ -8,7 +8,6 @@ import { createTheme } from "@material-ui/core/styles"; // v4.x
 import getMuiTheme from "material-ui/styles/getMuiTheme";
 
 import assemblePalette from "./assemble-palette";
-import baseTheme from "./theme";
 import type { CustomTheme } from "./types";
 
 export const createMuiThemev0 = (theme: Partial<CustomTheme> = {}) => {
@@ -17,7 +16,7 @@ export const createMuiThemev0 = (theme: Partial<CustomTheme> = {}) => {
 
   return getMuiTheme(
     {
-      fontFamily: "Karla",
+      fontFamily: "'Inter', sans-serif",
       palette: {
         primary1Color: primaryColor,
         textColor: theme.primaryTextColor || blueGrey[800],
@@ -38,12 +37,21 @@ export const createMuiThemev0 = (theme: Partial<CustomTheme> = {}) => {
 
 // TODO: return real theme once components beyond Dialog are converted
 export const createMuiThemev1 = (theme: Partial<CustomTheme> = {}) => {
-  const primaryColor = theme.primaryColor ?? assemblePalette.primary.navy;
-  const secondaryColor = theme.secondaryColor ?? assemblePalette.primary.navy;
+  const primaryColor = theme.primaryColor ?? assemblePalette.primary.indigo;
+  const secondaryColor = theme.secondaryColor ?? assemblePalette.primary.indigo;
   const infoColor = theme.infoColor ?? "#FF781D";
   const badgeColor = theme.badgeColor || assemblePalette.secondary.red;
 
   return createTheme({
+    typography: {
+      fontFamily: "'Inter', sans-serif",
+      button: {
+        textTransform: "none" as const
+      }
+    },
+    shape: {
+      borderRadius: 8
+    },
     palette: {
       primary: { main: primaryColor },
       secondary: { main: secondaryColor },
@@ -51,7 +59,7 @@ export const createMuiThemev1 = (theme: Partial<CustomTheme> = {}) => {
       convoMessageBadge: { main: yellow[600] },
       inboundMessageBg: { main: blue[500] },
       success: { main: theme.successColor || green[500], light: green[100] },
-      warning: { main: theme.warningColor || baseTheme.colors.orange },
+      warning: { main: theme.warningColor || "#F59E0B" },
       error: { main: theme.errorColor || red[200] },
       info: { main: infoColor, light: blue[100], dark: blue[900] },
       text: {
@@ -60,11 +68,124 @@ export const createMuiThemev1 = (theme: Partial<CustomTheme> = {}) => {
         secondary: theme.secondaryTextColor || "#333333"
       },
       background: {
-        default: theme.canvassColor || grey[50]
+        default: theme.canvassColor || assemblePalette.common.backgroundGray
       },
       action: {
         disabled: theme.disabledTextColor || blueGrey[800],
         disabledBackground: theme.disabledBackgroundColor || grey[300]
+      }
+    },
+    overrides: {
+      MuiButton: {
+        root: {
+          borderRadius: 8,
+          textTransform: "none" as const
+        },
+        contained: {
+          boxShadow: "none",
+          "&:hover": {
+            boxShadow: "none"
+          }
+        }
+      },
+      MuiPaper: {
+        elevation1: {
+          boxShadow: "none",
+          border: `1px solid ${assemblePalette.common.cardBorder}`
+        },
+        rounded: {
+          borderRadius: 8
+        }
+      },
+      MuiDialog: {
+        paperRounded: {
+          borderRadius: 12
+        }
+      },
+      MuiOutlinedInput: {
+        root: {
+          borderRadius: 8
+        },
+        notchedOutline: {
+          "& legend": {
+            fontSize: "0.85em"
+          }
+        }
+      },
+      MuiInputLabel: {
+        outlined: {
+          "&.MuiInputLabel-shrink": {
+            transform: "translate(14px, -6px) scale(0.75)"
+          }
+        }
+      },
+      MuiTextField: {
+        root: {
+          marginTop: 8,
+          marginBottom: 8
+        }
+      },
+      MuiFormControl: {
+        root: {
+          marginTop: 8,
+          marginBottom: 8
+        }
+      },
+      MuiTableCell: {
+        head: {
+          textTransform: "uppercase" as const,
+          fontSize: 12,
+          fontWeight: 600,
+          color: "#6B7280"
+        }
+      },
+      MuiFab: {
+        root: {
+          borderRadius: 8,
+          textTransform: "none" as const,
+          boxShadow:
+            "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)",
+          "&:hover": {
+            boxShadow:
+              "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)"
+          }
+        },
+        extended: {
+          borderRadius: 8
+        }
+      },
+      MuiSpeedDial: {
+        fab: {
+          borderRadius: 8,
+          border: 0,
+          background: "linear-gradient(to bottom left, #fde68a, #fbbf24)",
+          color: "#000000",
+          fontSize: "0.875rem",
+          fontWeight: 700,
+          padding: 8,
+          whiteSpace: "nowrap" as const,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 6,
+          transition: "background 0.2s ease, color 0.2s ease",
+          "&:hover": {
+            background: "linear-gradient(to bottom left, #fcd34d, #f59e0b)"
+          },
+          "&:focus-visible": {
+            outline: "none",
+            boxShadow: "0 0 0 2px #fff, 0 0 0 4px #1d4ed8"
+          },
+          "&.Mui-disabled": {
+            pointerEvents: "none",
+            opacity: 0.5
+          }
+        }
+      },
+      MuiSpeedDialAction: {
+        fab: {
+          borderRadius: 8
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary
- Button, card, and component polish across the app (Phase 4)
- Migrate AdminTagEditor form layout and TextFields to MUI v4

## Test plan
- [ ] Verify button styles and card layouts render correctly
- [ ] Verify AdminTagEditor form is functional with MUI v4 TextFields
- [ ] Check for visual regressions in other components

🤖 Generated with [Claude Code](https://claude.com/claude-code)