### PR TITLE
fix(message-review): check for empty name filter

### DIFF
--- a/src/containers/AdminIncomingMessageList/index.tsx
+++ b/src/containers/AdminIncomingMessageList/index.tsx
@@ -8,6 +8,7 @@ import {
   useMegaBulkReassignCampaignContactsMutation,
   useMegaReassignCampaignContactsMutation
 } from "@spoke/spoke-codegen";
+import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
 import omit from "lodash/omit";
 import React, { useState } from "react";
@@ -378,7 +379,7 @@ const AdminIncomingMessageList: React.FC<AdminIncomingMessageListProps> = (
       !isEqual(contactsFilter, initialContactsFilter) ||
       !isEqual(assignmentsFilter, initialAssignmentsFilter) ||
       !isEqual(tagsFilter, initialTagsFilter) ||
-      contactNameFilter !== undefined
+      !isEmpty(contactNameFilter)
     );
   };
 


### PR DESCRIPTION
## Description

This fixes the default check for the name filter in message review, which is an empty object by default (not undefined)

## Motivation and Context

Follow up to #95 - this was accidentally not included in the commit 

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
