### PR TITLE
fix(staging): match expected organization uuid format

### DIFF
--- a/seeds/staging/01-organizations.csv
+++ b/seeds/staging/01-organizations.csv
@@ -1,2 +1,2 @@
 id,name,uuid,features,texting_hours_enforced,texting_hours_start,texting_hours_end
-1,Staging Test Org,staging-test-org-uuid,"{}",false,9,21
+1,Staging Test Org,stagingt-est0-org0-uuid-000000000000,"{}",false,9,21


### PR DESCRIPTION
## Description

This updates the UUID used to create staging orgs to match the expected format 

## Motivation and Context

A UUID matching [this regex](https://github.com/With-the-Ranks/Spoke/blob/main/src/containers/Login/index.tsx#L84-L86) is required to get Spoke to display the "Sign Up" tab on a join link. Currently, users can't create new accounts on staging instances

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
