### PR TITLE
fix: avoid mutating frozen Apollo cache array in TexterTodoList

### DIFF
--- a/src/containers/TexterTodoList/index.jsx
+++ b/src/containers/TexterTodoList/index.jsx
@@ -48,7 +48,8 @@ class TexterTodoList extends React.Component {
 
   renderTodoList(assignments) {
     const { organizationId } = this.props.match.params;
-    return assignments.slice()
+    return assignments
+      .slice()
       .sort()
       .map((assignment) => {
         if (

--- a/src/containers/TexterTodoList/index.jsx
+++ b/src/containers/TexterTodoList/index.jsx
@@ -48,7 +48,7 @@ class TexterTodoList extends React.Component {
 
   renderTodoList(assignments) {
     const { organizationId } = this.props.match.params;
-    return assignments
+    return assignments.slice()
       .sort()
       .map((assignment) => {
         if (


### PR DESCRIPTION
## Summary
- Calling `.sort()` directly on the Apollo-cached `todos` array throws a `TypeError: Cannot assign to read only property` in development because Apollo freezes cache objects
- Fixed by calling `.slice()` first to sort a shallow copy, leaving the cache untouched

## Motivation and Context
Noticed this pop up randomly while playing around with the new UI. Haven't tracked it back to any recent changes, or a consistent way to reproduce, but the fix seems appropriate so proposing here

## Test plan
- [ ] Navigate to the texter todo list as a texter with active assignments — no error in the console
- [ ] Verify assignments still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)