### PR TITLE
fix: clear campaign teams when teamIds is empty array

### DIFF
--- a/src/server/api/lib/campaign.ts
+++ b/src/server/api/lib/campaign.ts
@@ -605,11 +605,13 @@ export const editCampaign = async (
       .where({ id });
   }
   if (Object.prototype.hasOwnProperty.call(campaign, "teamIds")) {
+    const { teamIds } = campaign;
     await r.knex.transaction(async (trx) => {
       // Remove all existing team memberships and then add everything again
       await trx("campaign_team").where({ campaign_id: id }).del();
+      if (!teamIds || teamIds.length < 1) return;
       await trx("campaign_team").insert(
-        campaign.teamIds?.map((team_id) => ({
+        teamIds.map((team_id) => ({
           team_id,
           campaign_id: id
         }))


### PR DESCRIPTION
## Summary
- When a user removes all teams from a campaign and saves, the teams were not being cleared
- Root cause: `knex('campaign_team').insert([])` throws when given an empty array, causing the transaction to roll back — including the preceding `del()` — so old teams remained
- Fix: skip the insert when `teamIds` is empty, matching the same pattern used for `campaignGroupIds`

## Test plan
- [ ] Add a team to a campaign and save
- [ ] Remove the team from the campaign and save again
- [ ] Verify the team no longer appears on the campaign

🤖 Generated with [Claude Code](https://claude.com/claude-code)