### PR TITLE
fix(v10 ui): tweaks from prod feedback

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -51,9 +51,7 @@ const useStyles = makeStyles((theme) => ({
   logoText: {
     fontWeight: 700,
     fontSize: 20,
-    color: theme.palette.primary.main,
-    whiteSpace: "nowrap",
-    overflow: "hidden"
+    color: theme.palette.primary.main
   },
   toggleBtn: {
     padding: 6,

--- a/src/containers/AdminBulkScriptEditor/index.tsx
+++ b/src/containers/AdminBulkScriptEditor/index.tsx
@@ -202,7 +202,6 @@ const AdminBulkScriptEditor: React.FC = (props) => {
 
   return (
     <div>
-      <h1>Bulk Script Editor</h1>
       <Paper variant="outlined" style={styles.paddedPaper}>
         <p style={{ fontSize: "1.3em" }}>Find and replace</p>
         <TextField

--- a/src/containers/TexterTodoList/components/TexterRequest.jsx
+++ b/src/containers/TexterTodoList/components/TexterRequest.jsx
@@ -225,28 +225,24 @@ class TexterRequest extends React.Component {
           value={{ email, count }}
           onSubmit={this.submit}
         >
-          <label htmlFor="count">
-            {" "}
-            Count:
-            <TextField
-              name="count"
-              label="Count"
-              variant="outlined"
-              size="small"
-              InputLabelProps={{ shrink: true }}
-              type="number"
-              value={count}
-              onChange={(e) => {
-                const formVal = parseInt(e.target.value, 10) || 0;
-                let newCount =
-                  maxRequestCount > 0
-                    ? Math.min(maxRequestCount, formVal)
-                    : formVal;
-                newCount = Math.max(newCount, 0);
-                this.setState({ count: newCount });
-              }}
-            />
-          </label>
+          <TextField
+            name="count"
+            label="Count"
+            variant="outlined"
+            size="small"
+            InputLabelProps={{ shrink: true }}
+            type="number"
+            value={count}
+            onChange={(e) => {
+              const formVal = parseInt(e.target.value, 10) || 0;
+              let newCount =
+                maxRequestCount > 0
+                  ? Math.min(maxRequestCount, formVal)
+                  : formVal;
+              newCount = Math.max(newCount, 0);
+              this.setState({ count: newCount });
+            }}
+          />
           <br />
           <Button
             variant="contained"


### PR DESCRIPTION
## Description

This includes a few tweaks for a cleaner UI:

1. Remove extra Bulk Script Editor title
2. Remove extra label for Texter Form Request count
3. Allow the organization title to wrap on the sidebar

## Motivation and Context

Noticed with testing v10 in prod

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<table>
  <thead>
    <tr>
      <th>UI Element</th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Bulk Script Editor</td>
      <td><img src="https://github.com/user-attachments/assets/2d39ee2f-b1c4-4355-9ead-dd7db3a57be6"></td>
      <td><img src="https://github.com/user-attachments/assets/6b8dee2a-f096-41b0-9f98-6ed2a42fabe5"></td>
    </tr>
    <tr>
      <td>Texter Form</td>
      <td><img src="https://github.com/user-attachments/assets/10731dbd-39e9-4d55-8292-e3d3599c664f"></td>
      <td><img src="https://github.com/user-attachments/assets/68998f15-3f4f-4174-b342-c91021169c87"></td>
    </tr>
    <tr>
      <td>Sidebar</td>
      <td><img src="https://github.com/user-attachments/assets/5d6bb401-f0b3-4e3b-9849-919b101a9ab7"></td>
      <td><img src="https://github.com/user-attachments/assets/36699ae5-635d-4775-80c2-aedcb0309098"></td>
    </tr>
  </tbody>
</table>









## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
