### PR TITLE
fix: correct multiLine -> multiline prop for MUI v4 in ContactActionDialog

### DIFF
--- a/src/containers/AssignmentTexterContact/components/ContactActionDialog.jsx
+++ b/src/containers/AssignmentTexterContact/components/ContactActionDialog.jsx
@@ -87,7 +87,7 @@ class ContactActionDialog extends Component {
                 this.contactActionTextRef = el;
               }}
             >
-              <SpokeFormField name={FIELD_NAME} fullWidth autoFocus multiLine />
+              <SpokeFormField name={FIELD_NAME} fullWidth autoFocus multiline />
             </div>
             <div className={css(styles.dialogActions)}>
               <Button


### PR DESCRIPTION
## Summary

- The `multiLine` prop (MUI v0 spelling) was passed to `SpokeFormField` in `ContactActionDialog`. After the visual refresh migrated to MUI v4, the correct prop name is `multiline` (all lowercase).
- With the wrong prop, the field rendered as `<input>` instead of `<textarea>`, causing the `querySelectorAll('textarea[name="messageText"]')` lookup in `componentDidMount` to return `undefined` and crash with: *Cannot read properties of undefined (reading 'addEventListener')*.

## Motivation and Context
Texters can't currently use the "opt out" button 🥲 

## Test plan

- [ ] Click the **Opt Out** button on a contact — dialog should open without a console error
- [ ] Confirm the opt-out message field is a multiline textarea
- [ ] Confirm Shift+Enter adds a newline; Enter alone does not submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)