### PR TITLE
feat: hide due date in campaigns list

### DIFF
--- a/src/containers/CampaignList/components/CampaignListRow.tsx
+++ b/src/containers/CampaignList/components/CampaignListRow.tsx
@@ -12,7 +12,6 @@ import React from "react";
 import { useHistory } from "react-router-dom";
 
 import { dataTest } from "../../../lib/attributes";
-import { DateTime } from "../../../lib/datetime";
 import type { CampaignOperationsProps } from "../utils";
 import CampaignListMenu from "./CampaignListMenu";
 
@@ -72,16 +71,8 @@ export const CampaignListRow: React.FC<Props> = (props) => {
       color: theme.palette.success.dark
     };
   }
-  const dueBy = DateTime.fromISO(campaign.dueBy || "");
   const creatorName = campaign.creator ? campaign.creator.displayName : null;
   let tags = [];
-  if (DateTime.local() >= dueBy) {
-    tags.push({
-      title: "Overdue",
-      color: theme.palette.grey[900],
-      backgroundColor: theme.palette.error.main
-    });
-  }
 
   if (externalSystem) {
     const title = `${externalSystem.type}: ${externalSystem.name}`;
@@ -124,7 +115,6 @@ export const CampaignListRow: React.FC<Props> = (props) => {
           label={tag.title}
           className={styles.chip}
           style={{
-            color: tag.color,
             backgroundColor: tag.backgroundColor
           }}
         />
@@ -139,7 +129,6 @@ export const CampaignListRow: React.FC<Props> = (props) => {
         {campaign.description}
         {creatorName ? <span> &mdash; Created by {creatorName}</span> : null}
         <br />
-        {dueBy.isValid ? dueBy.toFormat("DD") : "No due date set"}
       </span>
     </span>
   );


### PR DESCRIPTION
## Description

This hides a remaining mention of due date in the campaigns list

## Motivation and Context

After #146, we're no longer allowing campaign builders to pick a due date, so this warning may be confusing

Also opened #163 but we can probs wait till client feedback is in before we merge that

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
