### PR TITLE
feat: add Chatwoot support widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,6 @@ DB_MAX_POOL=10
 # Message Sending
 DEFAULT_SERVICE=fakeservice
 
-# Optional: Chatwoot in-app support (Report a bug). See README "Support widget (Chatwoot)".
-# CHATWOOT_BASE_URL=https://app.chatwoot.com
+# CHATWOOT_BASE_URL=
 # CHATWOOT_WEBSITE_TOKEN=
 

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,8 @@ DB_MAX_POOL=10
 
 # Message Sending
 DEFAULT_SERVICE=fakeservice
+
+# Optional: Chatwoot in-app support (Report a bug). See README "Support widget (Chatwoot)".
+# CHATWOOT_BASE_URL=https://app.chatwoot.com
+# CHATWOOT_WEBSITE_TOKEN=
+

--- a/README.md
+++ b/README.md
@@ -182,6 +182,13 @@ yarn knex migrate:make my-migration
 
 All configuration environment variables are documented in [config.js](./src/config.js).
 
+### Support widget (Chatwoot)
+
+When `CHATWOOT_BASE_URL` and `CHATWOOT_WEBSITE_TOKEN` are set, the server injects Chatwoot’s script in the HTML shell (see [`src/server/middleware/app-renderer.js`](src/server/middleware/app-renderer.js)).
+
+1. Create a **Website** inbox in [Chatwoot](https://www.chatwoot.com/) (cloud or self-hosted).
+2. Set `CHATWOOT_BASE_URL` and `CHATWOOT_WEBSITE_TOKEN` in your environment (see [config.js](./src/config.js)).
+
 You can also find developer documentation and guides in the [docs](./docs) directory.
 
 ## Contributing

--- a/src/config.js
+++ b/src/config.js
@@ -186,6 +186,18 @@ const validators = {
     desc: "The key prefix to use for memoredis memoization (memoredis)",
     default: undefined
   }),
+  CHATWOOT_BASE_URL: url({
+    desc: "Base URL of your Chatwoot installation for the website widget.",
+    example: "https://app.chatwoot.com",
+    default: undefined,
+    isClient: true
+  }),
+  CHATWOOT_WEBSITE_TOKEN: str({
+    desc:
+      "Website inbox token from Chatwoot Settings → Inboxes → Website channel.",
+    default: undefined,
+    isClient: true
+  }),
   CAMPAIGN_ID: num({
     desc:
       "Campaign ID used by dev-tools/export-query.js to identify which campaign should be exported.",

--- a/src/config.js
+++ b/src/config.js
@@ -187,14 +187,15 @@ const validators = {
     default: undefined
   }),
   CHATWOOT_BASE_URL: url({
-    desc: "Base URL of your Chatwoot installation for the website widget.",
+    desc:
+      "Optional Chatwoot website widget. Base URL of your Chatwoot install (no trailing slash). When set together with CHATWOOT_WEBSITE_TOKEN, the server injects the widget in the HTML shell (see app-renderer). README: Support widget (Chatwoot).",
     example: "https://app.chatwoot.com",
     default: undefined,
     isClient: true
   }),
   CHATWOOT_WEBSITE_TOKEN: str({
     desc:
-      "Website inbox token from Chatwoot Settings → Inboxes → Website channel.",
+      "Optional Chatwoot website widget. Website inbox token (Chatwoot Settings → Inboxes → Website). Must be set with CHATWOOT_BASE_URL to enable the launcher.",
     default: undefined,
     isClient: true
   }),

--- a/src/containers/AdminTemplateCampaigns/index.tsx
+++ b/src/containers/AdminTemplateCampaigns/index.tsx
@@ -11,6 +11,7 @@ import {
 import React, { useCallback } from "react";
 import { useHistory, useParams } from "react-router-dom";
 
+import spokeTheme from "../../styles/theme";
 import TemplateCampaignRow from "./components/TemplateCampaignRow";
 
 const useStyles = makeStyles((theme) => ({
@@ -18,11 +19,6 @@ const useStyles = makeStyles((theme) => ({
     "& > *": {
       margin: theme.spacing(1)
     }
-  },
-  fab: {
-    position: "absolute",
-    bottom: theme.spacing(2),
-    right: theme.spacing(2)
   }
 }));
 
@@ -105,7 +101,7 @@ export const AdminTemplateCampaigns: React.FC = () => {
       </div>
       <Fab
         color="primary"
-        className={classes.fab}
+        style={spokeTheme.components.floatingButton}
         aria-label="add"
         disabled={createTemplateLoading}
         onClick={handleClickCreateTemplate}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,6 +15,11 @@ interface Window {
   BASE_URL: string;
   ENABLE_TROLLBOT: boolean;
 
+  /** When set with CHATWOOT_BASE_URL, loads the Chatwoot support widget. */
+  CHATWOOT_WEBSITE_TOKEN?: string;
+  /** Chatwoot installation URL, e.g. https://app.chatwoot.com */
+  CHATWOOT_BASE_URL?: string;
+
   AuthService: any;
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,9 +15,7 @@ interface Window {
   BASE_URL: string;
   ENABLE_TROLLBOT: boolean;
 
-  /** When set with CHATWOOT_BASE_URL, loads the Chatwoot support widget. */
   CHATWOOT_WEBSITE_TOKEN?: string;
-  /** Chatwoot installation URL, e.g. https://app.chatwoot.com */
   CHATWOOT_BASE_URL?: string;
 
   AuthService: any;

--- a/src/server/middleware/app-renderer.js
+++ b/src/server/middleware/app-renderer.js
@@ -47,6 +47,33 @@ const externalLinks = config.NO_EXTERNAL_LINKS
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.auth0.com/js/lock/11.0.1/lock.min.js"></script>`;
 
+const chatwootBase = config.CHATWOOT_BASE_URL
+  ? String(config.CHATWOOT_BASE_URL).replace(/\/$/, "")
+  : "";
+const chatwootScript =
+  config.CHATWOOT_WEBSITE_TOKEN && chatwootBase
+    ? `
+    <script>
+      (function (d, t) {
+        var BASE_URL = ${JSON.stringify(chatwootBase)};
+        var TOKEN = ${JSON.stringify(config.CHATWOOT_WEBSITE_TOKEN)};
+        window.chatwootSettings = { hideMessageBubble: false };
+        var g = d.createElement(t),
+          s = d.getElementsByTagName(t)[0];
+        g.src = BASE_URL + "/packs/js/sdk.js";
+        g.async = true;
+        s.parentNode.insertBefore(g, s);
+        g.onload = function () {
+          window.chatwootSDK.run({
+            websiteToken: TOKEN,
+            baseUrl: BASE_URL
+          });
+        };
+      })(document, "script");
+    </script>
+  `
+    : "";
+
 const rollbarScript = config.ROLLBAR_ACCESS_TOKEN
   ? `
     <script>
@@ -99,6 +126,7 @@ const indexHtml = `
       ${windowVars.join("      \n")}
     </script>
     ${rollbarScript}
+    ${chatwootScript}
   </head>
   <body>
     <div id="mount"></div>

--- a/src/server/middleware/app-renderer.js
+++ b/src/server/middleware/app-renderer.js
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 
 import { clientConfig, config } from "../../config";
+import { r } from "../models";
 
 // -----------------------------------------
 // Asset Map
@@ -74,6 +75,19 @@ const chatwootScript =
   `
     : "";
 
+const shouldShowChatwoot = async (user) => {
+  if (!chatwootScript || !user) return false;
+  if (user.is_superadmin === true) return true;
+
+  const membership = await r
+    .reader("user_organization")
+    .where({ user_id: user.id })
+    .whereIn("role", ["ADMIN", "OWNER"])
+    .first("id");
+
+  return Boolean(membership);
+};
+
 const rollbarScript = config.ROLLBAR_ACCESS_TOKEN
   ? `
     <script>
@@ -139,6 +153,13 @@ const indexHtml = `
 // Middleware
 // -----------------------------------------
 
-const appRenderer = async (req, res) => res.send(indexHtml);
+const appRenderer = async (req, res, next) => {
+  try {
+    const showChatwoot = await shouldShowChatwoot(req.user);
+    res.send(showChatwoot ? indexHtml : indexHtml.replace(chatwootScript, ""));
+  } catch (err) {
+    next(err);
+  }
+};
 
 export default appRenderer;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -106,12 +106,20 @@ const layouts: LayoutStyles = {
   }
 };
 
+/** Extra bottom inset when Chatwoot launcher is enabled (window vars from app shell). */
+const chatwootFabBottomOffset =
+  typeof window !== "undefined" &&
+  window.CHATWOOT_WEBSITE_TOKEN &&
+  window.CHATWOOT_BASE_URL
+    ? 80
+    : 0;
+
 const components: ComponentStyles = {
   floatingButton: {
     margin: 0,
     top: "auto",
     right: 20,
-    bottom: 20,
+    bottom: 20 + chatwootFabBottomOffset,
     left: "auto",
     position: "fixed"
   },


### PR DESCRIPTION
## Description
- Closes #159 
- Adds optional Chatwoot website widget support so orgs can surface in-app support (the floating chat bubble) when configured.

## Motivation and Context

Add a way to offer Report a bug / support. Chatwoot is optional and off until env vars are set, so existing installs are unchanged.


## How Has This Been Tested?

-  Set CHATWOOT_BASE_URL and CHATWOOT_WEBSITE_TOKEN locally, run the app, confirm the launcher appears and conversations open in the configured inbox.
-  With vars unset, confirm no Chatwoot script in page source and no extra FAB offset.
-  In app, confirm Chatwoot chat on bottom right when the widget is enabled.

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->
<img width="216" height="195" alt="spoke-1" src="https://github.com/user-attachments/assets/763323ae-c8af-48dd-b6de-85ee485b6e24" />
<img width="230" height="387" alt="spoke-2" src="https://github.com/user-attachments/assets/c376fbba-2ab8-4b74-b908-dd697d03066b" />

## Documentation Changes

Updated README and .env.example to describe the feature.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have included updates for the documentation accordingly.
