### PR TITLE
feat(observability): add Phase 1 Prometheus metrics instrumentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,7 @@ DB_MAX_POOL=10
 
 # Message Sending
 DEFAULT_SERVICE=fakeservice
+
+# CHATWOOT_BASE_URL=
+# CHATWOOT_WEBSITE_TOKEN=
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [10.2.0](https://github.com/With-the-Ranks/spoke/compare/v10.1.0...v10.2.0) (2026-05-28)
+
+
+### Features
+
+* **message-review:** insert script when survey selected ([#179](https://github.com/With-the-Ranks/spoke/issues/179)) ([94dcec0](https://github.com/With-the-Ranks/spoke/commit/94dcec0811b17f5f52ea3846a563a9d71e9fbbbc))
+* add Chatwoot support widget ([#170](https://github.com/With-the-Ranks/spoke/issues/170)) ([91c7152](https://github.com/With-the-Ranks/spoke/commit/91c7152196d7464ce30e0092fc826fcc7869020e))
+
+
+### Bug Fixes
+
+* **campaign-preview:** remove text align justify style ([#173](https://github.com/With-the-Ranks/spoke/issues/173)) ([35cee18](https://github.com/With-the-Ranks/spoke/commit/35cee1881aec3ff30c6cb9ca9eab0293a6104626))
+* **campaign-preview:** scope collapse/expand toggle to chevron only ([#174](https://github.com/With-the-Ranks/spoke/issues/174)) ([f631a02](https://github.com/With-the-Ranks/spoke/commit/f631a02e426fe6b0a0873f48b6a6c101ae86abf1))
+* center login form ([#172](https://github.com/With-the-Ranks/spoke/issues/172)) ([a0a0ae3](https://github.com/With-the-Ranks/spoke/commit/a0a0ae3a592c50a5765338ff6607492ad403f2ad))
+* **van:** use mui v4 components for setup dialog ([#185](https://github.com/With-the-Ranks/spoke/issues/185)) ([91fe906](https://github.com/With-the-Ranks/spoke/commit/91fe906a6729cb57d7c1ef2b21718f4e7b37d62c))
+
 ## [10.1.0](https://github.com/With-the-Ranks/spoke/compare/v10.0.1...v10.1.0) (2026-05-06)
 
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,13 @@ yarn knex migrate:make my-migration
 
 All configuration environment variables are documented in [config.js](./src/config.js).
 
+### Support widget (Chatwoot)
+
+When `CHATWOOT_BASE_URL` and `CHATWOOT_WEBSITE_TOKEN` are set, the server injects Chatwoot’s script in the HTML shell (see [`src/server/middleware/app-renderer.js`](src/server/middleware/app-renderer.js)).
+
+1. Create a **Website** inbox in [Chatwoot](https://www.chatwoot.com/) (cloud or self-hosted).
+2. Set `CHATWOOT_BASE_URL` and `CHATWOOT_WEBSITE_TOKEN` in your environment (see [config.js](./src/config.js)).
+
 You can also find developer documentation and guides in the [docs](./docs) directory.
 
 ## Contributing

--- a/monitoring/grafana/alert-rules.yaml
+++ b/monitoring/grafana/alert-rules.yaml
@@ -1,0 +1,313 @@
+# Grafana alerting provisioning — Spoke alert rules
+#
+# Format: Grafana v1 provisioning (https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/)
+#
+# This file is the human-readable source of truth for all Spoke alert rules.
+# Use apply.sh to push these rules to Grafana Cloud via the HTTP API.
+#
+# Datasource: replace __PROMETHEUS_DS_UID__ with the UID of your GMP Prometheus
+# datasource in Grafana Cloud (apply.sh fetches this automatically).
+
+apiVersion: 1
+
+groups:
+  # ---------------------------------------------------------------------------
+  # HTTP
+  # ---------------------------------------------------------------------------
+  - orgId: 1
+    name: spoke-http
+    folder: Spoke
+    interval: 1m
+    rules:
+      - uid: spoke-http-5xx
+        title: "HTTP 5xx Error Rate High"
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __PROMETHEUS_DS_UID__
+            model:
+              expr: >
+                sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+                /
+                sum(rate(http_requests_total[5m]))
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: "-100"
+            model:
+              type: threshold
+              refId: B
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0.05]
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        missingSeriesEvalsToResolve: 1
+        keepFiringFor: 0s
+        for: 5m
+        labels:
+          severity: critical
+          team: eng
+        annotations:
+          summary: "HTTP 5xx error rate above 5%"
+          description: >
+            The HTTP 5xx error rate is {{ $values.A.Value | humanizePercentage }} over the last
+            5 minutes. Investigate application logs and recent deployments.
+
+  # ---------------------------------------------------------------------------
+  # GraphQL
+  # ---------------------------------------------------------------------------
+  - orgId: 1
+    name: spoke-graphql
+    folder: Spoke
+    interval: 1m
+    rules:
+      - uid: spoke-gql-latency
+        title: "GraphQL P95 Latency High"
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __PROMETHEUS_DS_UID__
+            model:
+              expr: >
+                histogram_quantile(
+                  0.95,
+                  sum(rate(graphql_request_duration_seconds_bucket[5m])) by (le)
+                )
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: "-100"
+            model:
+              type: threshold
+              refId: B
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [2]
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        missingSeriesEvalsToResolve: 1
+        keepFiringFor: 0s
+        for: 5m
+        labels:
+          severity: critical
+          team: eng
+        annotations:
+          summary: "GraphQL P95 latency above 2 s"
+          description: >
+            The 95th-percentile GraphQL response time is {{ $values.A.Value | humanizeDuration }}
+            over the last 5 minutes. Check slow resolvers and database query times.
+
+  # ---------------------------------------------------------------------------
+  # SMS
+  # ---------------------------------------------------------------------------
+  - orgId: 1
+    name: spoke-sms
+    folder: Spoke
+    interval: 1m
+    rules:
+      - uid: spoke-sms-errors
+        title: "SMS Send Error Rate High"
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __PROMETHEUS_DS_UID__
+            model:
+              # Only fire when there is meaningful send volume (> 1 msg/min)
+              # to avoid spurious alerts during quiet periods.
+              expr: >
+                (
+                  sum(rate(spoke_sms_send_total{status="error"}[5m]))
+                  /
+                  sum(rate(spoke_sms_send_total[5m]))
+                ) and sum(rate(spoke_sms_send_total[5m])) > 0.016
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: "-100"
+            model:
+              type: threshold
+              refId: B
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0.05]
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        missingSeriesEvalsToResolve: 1
+        keepFiringFor: 0s
+        for: 5m
+        labels:
+          severity: critical
+          team: eng
+        annotations:
+          summary: "SMS send error rate above 5%"
+          description: >
+            {{ $values.A.Value | humanizePercentage }} of SMS sends are failing over the last
+            5 minutes. Check the Switchboard/Twilio/Nexmo status page and outbound
+            webhook logs.
+
+  # ---------------------------------------------------------------------------
+  # Worker
+  # ---------------------------------------------------------------------------
+  - orgId: 1
+    name: spoke-worker
+    folder: Spoke
+    interval: 1m
+    rules:
+      - uid: spoke-worker-fail
+        title: "Graphile Worker Task Failures"
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __PROMETHEUS_DS_UID__
+            model:
+              expr: >
+                sum by (task_identifier) (
+                  increase(worker_task_total{status="error"}[5m])
+                )
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: "-100"
+            model:
+              type: threshold
+              refId: B
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        missingSeriesEvalsToResolve: 1
+        keepFiringFor: 0s
+        for: 5m
+        labels:
+          severity: warning
+          team: eng
+        annotations:
+          summary: "Graphile Worker task failures detected"
+          description: >
+            Task "{{ $labels.task_identifier }}" has failed {{ $values.A.Value }} time(s) in the
+            last 5 minutes. Check worker logs and the graphile_worker.jobs table for
+            error details.
+
+  # ---------------------------------------------------------------------------
+  # Database
+  # ---------------------------------------------------------------------------
+  - orgId: 1
+    name: spoke-database
+    folder: Spoke
+    interval: 1m
+    rules:
+      - uid: spoke-db-pool
+        title: "DB Connection Pool Saturation High"
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __PROMETHEUS_DS_UID__
+            model:
+              expr: >
+                sum by (db) (db_pool_connections{state="active"})
+                /
+                (
+                  sum by (db) (db_pool_connections{state="active"})
+                  + sum by (db) (db_pool_connections{state="idle"})
+                )
+              instant: true
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: "-100"
+            model:
+              type: threshold
+              refId: B
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0.80]
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        missingSeriesEvalsToResolve: 1
+        keepFiringFor: 0s
+        for: 5m
+        labels:
+          severity: critical
+          team: eng
+        annotations:
+          summary: "DB connection pool above 80% utilized"
+          description: >
+            The {{ $labels.db }} Postgres connection pool is {{ $values.A.Value | humanizePercentage }}
+            utilized for the last 5 minutes. Consider increasing DB_MAX_POOL or
+            investigating long-running queries.

--- a/monitoring/grafana/apply.sh
+++ b/monitoring/grafana/apply.sh
@@ -1,0 +1,496 @@
+#!/usr/bin/env bash
+# apply.sh — Push Spoke alert rules, contact points, and notification policy
+#             to a Grafana Cloud instance via the HTTP API.
+#
+# Required environment variables:
+#   GRAFANA_URL          e.g. https://yourstack.grafana.net  (no trailing slash)
+#   GRAFANA_SA_TOKEN     Service account token with Admin role
+#
+# For contact points to work, also set:
+#   ONCALL_WEBHOOK_URL   Grafana OnCall integration webhook URL (create a
+#                        "Grafana Alerting" integration in OnCall to get this)
+#   SLACK_WEBHOOK_URL    Incoming webhook URL for #alerts-spoke
+#
+# Usage:
+#   export GRAFANA_URL=https://yourstack.grafana.net
+#   export GRAFANA_SA_TOKEN=glsa_xxxxxxxxxxxx
+#   export ONCALL_WEBHOOK_URL=https://oncall-prod-us-central-0.grafana.net/oncall/integrations/v1/grafana/...
+#   export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+#   bash monitoring/grafana/apply.sh
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+: "${GRAFANA_URL:?GRAFANA_URL is required}"
+: "${GRAFANA_SA_TOKEN:?GRAFANA_SA_TOKEN is required}"
+
+BASE="${GRAFANA_URL%/}"
+AUTH="Authorization: Bearer ${GRAFANA_SA_TOKEN}"
+
+grafana_curl() {
+  local method="$1"; shift
+  curl --silent --show-error --fail \
+    -X "$method" \
+    -H "$AUTH" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+echo "→ Target: $BASE"
+
+# ---------------------------------------------------------------------------
+# 1. Create (or retrieve) the Spoke folder
+# ---------------------------------------------------------------------------
+echo "→ Ensuring 'Spoke' folder exists..."
+
+FOLDER_RESPONSE=$(grafana_curl POST "$BASE/api/folders" \
+  -d '{"title":"Spoke","uid":"spoke"}' 2>/dev/null \
+  || grafana_curl GET "$BASE/api/folders/spoke")
+
+FOLDER_UID=$(echo "$FOLDER_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['uid'])")
+echo "   Folder UID: $FOLDER_UID"
+
+# ---------------------------------------------------------------------------
+# 2. Detect Prometheus datasource UID
+# ---------------------------------------------------------------------------
+echo "→ Detecting Prometheus datasource UID..."
+
+DS_RESPONSE=$(grafana_curl GET "$BASE/api/datasources")
+PROMETHEUS_DS_UID=$(echo "$DS_RESPONSE" | python3 -c "
+import sys, json
+sources = json.load(sys.stdin)
+prom = next(
+    (s for s in sources if s.get('type') == 'prometheus'),
+    None
+)
+if not prom:
+    raise SystemExit('No Prometheus datasource found. Add one in Grafana Cloud first.')
+print(prom['uid'])
+")
+echo "   Prometheus datasource UID: $PROMETHEUS_DS_UID"
+
+# ---------------------------------------------------------------------------
+# 3. Contact points
+# ---------------------------------------------------------------------------
+echo "→ Applying contact points..."
+
+ONCALL_WEBHOOK_URL="${ONCALL_WEBHOOK_URL:-REPLACE_ME}"
+SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-REPLACE_ME}"
+
+if [ "$ONCALL_WEBHOOK_URL" = "REPLACE_ME" ]; then
+  echo "   ⚠  ONCALL_WEBHOOK_URL not set — oncall-critical will be scaffolded with a placeholder"
+fi
+if [ "$SLACK_WEBHOOK_URL" = "REPLACE_ME" ]; then
+  echo "   ⚠  SLACK_WEBHOOK_URL not set — slack-warnings will be scaffolded with a placeholder"
+fi
+
+# Upsert a contact point: PUT to update if it exists, POST to create if not.
+upsert_contact_point() {
+  local uid="$1"
+  local body="$2"
+  local name="$3"
+  if ! grafana_curl PUT "$BASE/api/v1/provisioning/contact-points/$uid" \
+      -d "$body" > /dev/null 2>&1; then
+    grafana_curl POST "$BASE/api/v1/provisioning/contact-points" \
+      -d "$body" > /dev/null
+  fi
+  echo "   ✓ $name"
+}
+
+upsert_contact_point "oncall-critical-recv" "$(cat <<JSON
+{
+  "name": "oncall-critical",
+  "type": "webhook",
+  "uid": "oncall-critical-recv",
+  "disableResolveMessage": false,
+  "settings": {
+    "url": "${ONCALL_WEBHOOK_URL}",
+    "httpMethod": "POST",
+    "maxAlerts": 0
+  }
+}
+JSON
+)" "oncall-critical"
+
+upsert_contact_point "slack-warnings-recv" "$(cat <<JSON
+{
+  "name": "slack-warnings",
+  "type": "slack",
+  "uid": "slack-warnings-recv",
+  "disableResolveMessage": true,
+  "settings": {
+    "url": "${SLACK_WEBHOOK_URL}",
+    "channel": "#alerts-spoke",
+    "username": "Grafana Alerts",
+    "icon_emoji": ":grafana:",
+    "title": "[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }}",
+    "text": "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+  }
+}
+JSON
+)" "slack-warnings"
+
+# ---------------------------------------------------------------------------
+# 4. Notification policy
+# ---------------------------------------------------------------------------
+echo "→ Applying notification policy..."
+
+grafana_curl PUT "$BASE/api/v1/provisioning/policies" -d "$(cat <<'JSON'
+{
+  "receiver": "slack-warnings",
+  "group_by": ["alertname", "environment"],
+  "group_wait": "30s",
+  "group_interval": "5m",
+  "repeat_interval": "4h",
+  "routes": [
+    {
+      "receiver": "oncall-critical",
+      "matchers": ["severity = critical"],
+      "group_wait": "10s",
+      "group_interval": "1m",
+      "repeat_interval": "1h",
+      "continue": false
+    },
+    {
+      "receiver": "slack-warnings",
+      "matchers": ["severity = warning"],
+      "group_wait": "1m",
+      "group_interval": "5m",
+      "repeat_interval": "8h",
+      "continue": false
+    }
+  ]
+}
+JSON
+)" > /dev/null
+echo "   ✓ notification policy"
+
+# ---------------------------------------------------------------------------
+# 5. Alert rules
+#
+# Each group is posted to /api/ruler/grafana/api/v1/rules/{folderUID}.
+# Posting a group replaces it entirely, making this idempotent.
+# ---------------------------------------------------------------------------
+echo "→ Applying alert rules..."
+
+rule() {
+  # Usage: rule <group-name> <JSON-body>
+  local group="$1"
+  local body="$2"
+  local http_status response
+  # Capture body + status without --fail so we can surface the API error.
+  response=$(curl --silent \
+    -X POST \
+    -H "$AUTH" \
+    -H "Content-Type: application/json" \
+    -w "\n%{http_code}" \
+    "$BASE/api/ruler/grafana/api/v1/rules/$FOLDER_UID" \
+    -d "$body")
+  http_status=$(echo "$response" | tail -n1)
+  if [ "$http_status" -ge 400 ]; then
+    echo "   ✗ $group → HTTP $http_status"
+    echo "$response" | sed '$d'
+    return 1
+  fi
+  echo "   ✓ $group"
+}
+
+# --- HTTP ---
+rule "spoke-http" "$(cat <<JSON
+{
+  "name": "spoke-http",
+  "interval": "1m",
+  "rules": [
+    {
+      "grafana_alert": {
+        "uid": "spoke-http-5xx",
+        "title": "HTTP 5xx Error Rate High",
+        "condition": "B",
+        "no_data_state": "OK",
+        "exec_err_state": "OK",
+        "missing_series_evals_to_resolve": 1,
+        "data": [
+          {
+            "refId": "A",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "$PROMETHEUS_DS_UID",
+            "model": {
+              "expr": "sum(rate(http_requests_total{status_code=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m]))",
+              "instant": true,
+              "refId": "A"
+            }
+          },
+          {
+            "refId": "B",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "-100",
+            "model": {
+              "type": "threshold",
+              "refId": "B",
+              "expression": "A",
+              "conditions": [
+                {
+                  "evaluator": {"type": "gt", "params": [0.05]},
+                  "operator": {"type": "and"},
+                  "query": {"params": ["A"]},
+                  "reducer": {"type": "last"},
+                  "type": "query"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "for": "5m",
+      "keep_firing_for": "0s",
+      "labels": {"severity": "critical", "team": "eng"},
+      "annotations": {
+        "summary": "HTTP 5xx error rate above 5%",
+        "description": "The HTTP 5xx error rate is {{ \$values.A.Value | humanizePercentage }} over the last 5 minutes. Investigate application logs and recent deployments."
+      }
+    }
+  ]
+}
+JSON
+)"
+
+# --- GraphQL ---
+rule "spoke-graphql" "$(cat <<JSON
+{
+  "name": "spoke-graphql",
+  "interval": "1m",
+  "rules": [
+    {
+      "grafana_alert": {
+        "uid": "spoke-gql-latency",
+        "title": "GraphQL P95 Latency High",
+        "condition": "B",
+        "no_data_state": "OK",
+        "exec_err_state": "OK",
+        "missing_series_evals_to_resolve": 1,
+        "data": [
+          {
+            "refId": "A",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "$PROMETHEUS_DS_UID",
+            "model": {
+              "expr": "histogram_quantile(0.95, sum(rate(graphql_request_duration_seconds_bucket[5m])) by (le))",
+              "instant": true,
+              "refId": "A"
+            }
+          },
+          {
+            "refId": "B",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "-100",
+            "model": {
+              "type": "threshold",
+              "refId": "B",
+              "expression": "A",
+              "conditions": [
+                {
+                  "evaluator": {"type": "gt", "params": [2]},
+                  "operator": {"type": "and"},
+                  "query": {"params": ["A"]},
+                  "reducer": {"type": "last"},
+                  "type": "query"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "for": "5m",
+      "keep_firing_for": "0s",
+      "labels": {"severity": "critical", "team": "eng"},
+      "annotations": {
+        "summary": "GraphQL P95 latency above 2 s",
+        "description": "The 95th-percentile GraphQL response time is {{ \$values.A.Value | humanizeDuration }} over the last 5 minutes. Check slow resolvers and database query times."
+      }
+    }
+  ]
+}
+JSON
+)"
+
+# --- SMS ---
+rule "spoke-sms" "$(cat <<JSON
+{
+  "name": "spoke-sms",
+  "interval": "1m",
+  "rules": [
+    {
+      "grafana_alert": {
+        "uid": "spoke-sms-errors",
+        "title": "SMS Send Error Rate High",
+        "condition": "B",
+        "no_data_state": "OK",
+        "exec_err_state": "OK",
+        "missing_series_evals_to_resolve": 1,
+        "data": [
+          {
+            "refId": "A",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "$PROMETHEUS_DS_UID",
+            "model": {
+              "expr": "(sum(rate(spoke_sms_send_total{status=\"error\"}[5m])) / sum(rate(spoke_sms_send_total[5m]))) and sum(rate(spoke_sms_send_total[5m])) > 0.016",
+              "instant": true,
+              "refId": "A"
+            }
+          },
+          {
+            "refId": "B",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "-100",
+            "model": {
+              "type": "threshold",
+              "refId": "B",
+              "expression": "A",
+              "conditions": [
+                {
+                  "evaluator": {"type": "gt", "params": [0.05]},
+                  "operator": {"type": "and"},
+                  "query": {"params": ["A"]},
+                  "reducer": {"type": "last"},
+                  "type": "query"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "for": "5m",
+      "keep_firing_for": "0s",
+      "labels": {"severity": "critical", "team": "eng"},
+      "annotations": {
+        "summary": "SMS send error rate above 5%",
+        "description": "{{ \$values.A.Value | humanizePercentage }} of SMS sends are failing over the last 5 minutes. Check the Switchboard/Twilio/Nexmo status page and outbound webhook logs."
+      }
+    }
+  ]
+}
+JSON
+)"
+
+# --- Worker ---
+rule "spoke-worker" "$(cat <<JSON
+{
+  "name": "spoke-worker",
+  "interval": "1m",
+  "rules": [
+    {
+      "grafana_alert": {
+        "uid": "spoke-worker-fail",
+        "title": "Graphile Worker Task Failures",
+        "condition": "B",
+        "no_data_state": "OK",
+        "exec_err_state": "OK",
+        "missing_series_evals_to_resolve": 1,
+        "data": [
+          {
+            "refId": "A",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "$PROMETHEUS_DS_UID",
+            "model": {
+              "expr": "sum by (task_identifier) (increase(worker_task_total{status=\"error\"}[5m]))",
+              "instant": true,
+              "refId": "A"
+            }
+          },
+          {
+            "refId": "B",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "-100",
+            "model": {
+              "type": "threshold",
+              "refId": "B",
+              "expression": "A",
+              "conditions": [
+                {
+                  "evaluator": {"type": "gt", "params": [0]},
+                  "operator": {"type": "and"},
+                  "query": {"params": ["A"]},
+                  "reducer": {"type": "last"},
+                  "type": "query"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "for": "5m",
+      "keep_firing_for": "0s",
+      "labels": {"severity": "warning", "team": "eng"},
+      "annotations": {
+        "summary": "Graphile Worker task failures detected",
+        "description": "Task \"{{ \$labels.task_identifier }}\" has failed {{ \$values.A.Value }} time(s) in the last 5 minutes. Check worker logs and the graphile_worker.jobs table for error details."
+      }
+    }
+  ]
+}
+JSON
+)"
+
+# --- Database ---
+rule "spoke-database" "$(cat <<JSON
+{
+  "name": "spoke-database",
+  "interval": "1m",
+  "rules": [
+    {
+      "grafana_alert": {
+        "uid": "spoke-db-pool",
+        "title": "DB Connection Pool Saturation High",
+        "condition": "B",
+        "no_data_state": "OK",
+        "exec_err_state": "OK",
+        "missing_series_evals_to_resolve": 1,
+        "data": [
+          {
+            "refId": "A",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "$PROMETHEUS_DS_UID",
+            "model": {
+              "expr": "sum by (db) (db_pool_connections{state=\"active\"}) / (sum by (db) (db_pool_connections{state=\"active\"}) + sum by (db) (db_pool_connections{state=\"idle\"}))",
+              "instant": true,
+              "refId": "A"
+            }
+          },
+          {
+            "refId": "B",
+            "relativeTimeRange": {"from": 300, "to": 0},
+            "datasourceUid": "-100",
+            "model": {
+              "type": "threshold",
+              "refId": "B",
+              "expression": "A",
+              "conditions": [
+                {
+                  "evaluator": {"type": "gt", "params": [0.80]},
+                  "operator": {"type": "and"},
+                  "query": {"params": ["A"]},
+                  "reducer": {"type": "last"},
+                  "type": "query"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "for": "5m",
+      "keep_firing_for": "0s",
+      "labels": {"severity": "critical", "team": "eng"},
+      "annotations": {
+        "summary": "DB connection pool above 80% utilized",
+        "description": "The {{ \$labels.db }} Postgres connection pool is {{ \$values.A.Value | humanizePercentage }} utilized for the last 5 minutes. Consider increasing DB_MAX_POOL or investigating long-running queries."
+      }
+    }
+  ]
+}
+JSON
+)"
+
+echo ""
+echo "✓ All done. Open $BASE/alerting/list to verify."

--- a/monitoring/grafana/contact-points.yaml
+++ b/monitoring/grafana/contact-points.yaml
@@ -1,0 +1,40 @@
+# Grafana alerting provisioning — contact points
+#
+# These are scaffolded. Before running apply.sh, set the required environment
+# variables (see apply.sh for the full list) so tokens are never committed.
+#
+# Grafana OnCall: Create a "Grafana Alerting" integration in OnCall
+#                 (Alerts & IRM → OnCall → Integrations → New integration)
+#                 and copy the webhook URL it generates into ONCALL_WEBHOOK_URL.
+#                 Docs: https://grafana.com/docs/oncall/latest/integrations/grafana-alerting/
+# Slack:          https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/slack/
+
+apiVersion: 1
+
+contactPoints:
+  # Critical alerts — pages on-call via Grafana OnCall
+  - orgId: 1
+    name: oncall-critical
+    receivers:
+      - uid: oncall-critical-recv
+        type: webhook
+        settings:
+          url: "${ONCALL_WEBHOOK_URL}"
+          httpMethod: POST
+          maxAlerts: 0
+        disableResolveMessage: false
+
+  # Warning alerts — posts to Slack channel
+  - orgId: 1
+    name: slack-warnings
+    receivers:
+      - uid: slack-warnings-recv
+        type: slack
+        settings:
+          url: "${SLACK_WEBHOOK_URL}"
+          channel: "#alerts-spoke"
+          username: "Grafana Alerts"
+          icon_emoji: ":grafana:"
+          title: "[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }}"
+          text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+        disableResolveMessage: true

--- a/monitoring/grafana/notification-policy.yaml
+++ b/monitoring/grafana/notification-policy.yaml
@@ -1,0 +1,32 @@
+# Grafana alerting provisioning — notification routing policy
+#
+# Routing logic:
+#   severity=critical  →  oncall-critical  (pages on-call via Grafana OnCall)
+#   severity=warning   →  slack-warnings   (Slack only)
+#   everything else    →  slack-warnings (fallback for unmatched alerts)
+
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: slack-warnings
+    group_by: [alertname, environment]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    routes:
+      - receiver: oncall-critical
+        matchers:
+          - severity = critical
+        group_wait: 10s
+        group_interval: 1m
+        repeat_interval: 1h
+        continue: false
+
+      - receiver: slack-warnings
+        matchers:
+          - severity = warning
+        group_wait: 1m
+        group_interval: 5m
+        repeat_interval: 8h
+        continue: false

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "pg": "^8.5.1",
     "pg-copy-streams": "^7.0.0",
     "pg-promise": "^10.12.0",
+    "prom-client": "^15.1.3",
     "promise-retry": "^2.0.1",
     "prop-types": "^15.6.0",
     "query-string": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoke",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "description": "Spoke",
   "main": "src/server",
   "engines": {
@@ -82,6 +82,10 @@
     "@mui/x-data-grid-pro": "4",
     "@mui/x-license-pro": "4",
     "@npcz/magic": "^1.3.13",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "^0.76.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+    "@opentelemetry/sdk-node": "^0.218.0",
     "@passport-next/passport": "^3.1.0",
     "@rewired/passport-slack": "^1.0.6",
     "@rooks/use-intersection-observer-ref": "^4.11.2",

--- a/src/config.js
+++ b/src/config.js
@@ -182,6 +182,11 @@ const validators = {
     desc: "This enables caching using simple memoization (memoredis)",
     default: undefined
   }),
+  CLIENT_LABEL: str({
+    desc:
+      "Label identifying this Spoke instance (e.g. 'fobs'). Attached to all Prometheus metrics as a 'client' label to support per-instance filtering in Grafana.",
+    default: "default"
+  }),
   CACHING_PREFIX: str({
     desc: "The key prefix to use for memoredis memoization (memoredis)",
     default: undefined
@@ -462,6 +467,10 @@ const validators = {
       "The maximum size for a message that a texter can send. When you send a SMS message over 160 characters the message will be split, so you might want to set this as 160 or less if you have a high SMS-only target demographic.",
     default: 99999,
     isClient: true
+  }),
+  METRICS_ENABLED: bool({
+    desc: "Whether to expose the /metrics endpoint for Prometheus scraping.",
+    default: true
   }),
   MODE: str({
     desc: "Server mode",

--- a/src/config.js
+++ b/src/config.js
@@ -186,6 +186,19 @@ const validators = {
     desc: "The key prefix to use for memoredis memoization (memoredis)",
     default: undefined
   }),
+  CHATWOOT_BASE_URL: url({
+    desc:
+      "Optional Chatwoot website widget. Base URL of your Chatwoot install (no trailing slash). When set together with CHATWOOT_WEBSITE_TOKEN, the server injects the widget in the HTML shell (see app-renderer). README: Support widget (Chatwoot).",
+    example: "https://app.chatwoot.com",
+    default: undefined,
+    isClient: true
+  }),
+  CHATWOOT_WEBSITE_TOKEN: str({
+    desc:
+      "Optional Chatwoot website widget. Website inbox token (Chatwoot Settings → Inboxes → Website). Must be set with CHATWOOT_BASE_URL to enable the launcher.",
+    default: undefined,
+    isClient: true
+  }),
   CAMPAIGN_ID: num({
     desc:
       "Campaign ID used by dev-tools/export-query.js to identify which campaign should be exported.",
@@ -466,6 +479,30 @@ const validators = {
   METRICS_ENABLED: bool({
     desc: "Whether to expose the /metrics endpoint for Prometheus scraping.",
     default: true
+  }),
+  DEPLOY_ENVIRONMENT: str({
+    desc:
+      "Deployment environment label for metrics, logs, and traces (e.g. 'production', 'staging'). Independent of NODE_ENV — staging deployments run with NODE_ENV=production but DEPLOY_ENVIRONMENT=staging so observability can distinguish them.",
+    default: "development"
+  }),
+  OTEL_ENABLED: bool({
+    desc: "Whether to enable OpenTelemetry distributed tracing.",
+    default: false
+  }),
+  OTEL_EXPORTER_OTLP_ENDPOINT: str({
+    desc:
+      "OTLP HTTP endpoint for trace export (e.g. Grafana Cloud Tempo push URL).",
+    example: "https://tempo-prod.grafana.net/tempo",
+    default: undefined
+  }),
+  OTEL_SERVICE_NAME: str({
+    desc: "Service name attached to every trace span.",
+    default: "spoke"
+  }),
+  OTEL_SAMPLE_RATE: num({
+    desc:
+      "Fraction of traces to sample (0.0–1.0). Use a low value in production.",
+    default: 0.1
   }),
   MODE: str({
     desc: "Server mode",

--- a/src/config.js
+++ b/src/config.js
@@ -182,11 +182,6 @@ const validators = {
     desc: "This enables caching using simple memoization (memoredis)",
     default: undefined
   }),
-  CLIENT_LABEL: str({
-    desc:
-      "Label identifying this Spoke instance (e.g. 'fobs'). Attached to all Prometheus metrics as a 'client' label to support per-instance filtering in Grafana.",
-    default: "default"
-  }),
   CACHING_PREFIX: str({
     desc: "The key prefix to use for memoredis memoization (memoredis)",
     default: undefined

--- a/src/containers/AdminExternalSystems.tsx
+++ b/src/containers/AdminExternalSystems.tsx
@@ -7,7 +7,11 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import Fab from "@material-ui/core/Fab";
+import FormControl from "@material-ui/core/FormControl";
+import InputLabel from "@material-ui/core/InputLabel";
+import MenuItem from "@material-ui/core/MenuItem";
 import Paper from "@material-ui/core/Paper";
+import Select from "@material-ui/core/Select";
 import Snackbar from "@material-ui/core/Snackbar";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -15,20 +19,19 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
+import TextField from "@material-ui/core/TextField";
 import AddIcon from "@material-ui/icons/Add";
 import CloudDownloadIcon from "@material-ui/icons/CloudDownload";
 import CreateIcon from "@material-ui/icons/Create";
 import RefreshIcon from "@material-ui/icons/Refresh";
 import type { ExternalSystem, ExternalSystemInput } from "@spoke/spoke-codegen";
+import { ExternalSystemType, VanOperationMode } from "@spoke/spoke-codegen";
 import type { History } from "history";
-import MenuItem from "material-ui/MenuItem";
-import SelectField from "material-ui/SelectField";
-import TextField from "material-ui/TextField";
 import React, { Component } from "react";
 import { Link, withRouter } from "react-router-dom";
 import { compose } from "recompose";
 
-import { ExternalSystemType, VanOperationMode } from "../api/external-system";
+import type { RelayPaginatedResponse } from "../api/pagination";
 import { DateTime } from "../lib/datetime";
 import type { MutationMap, QueryMap } from "../network/types";
 import theme from "../styles/theme";
@@ -36,9 +39,20 @@ import { loadData } from "./hoc/with-operations";
 
 const EXTERNAL_SYSTEM_OPTS: [string, string][] = [["Votebuilder", "VAN"]];
 const OPERATION_MODE_OPTS: [string, string][] = [
-  ["Voterfile", VanOperationMode.VOTERFILE],
-  ["MyCampaign", VanOperationMode.MYCAMPAIGN]
+  ["Voterfile", VanOperationMode.Voterfile],
+  ["MyCampaign", VanOperationMode.Mycampaign]
 ];
+
+const externalSystemTypeValues = new Set<string>(
+  Object.values(ExternalSystemType)
+);
+const vanOperationModeValues = new Set<string>(Object.values(VanOperationMode));
+
+const isExternalSystemType = (value: unknown): value is ExternalSystemType =>
+  typeof value === "string" && externalSystemTypeValues.has(value);
+
+const isVanOperationMode = (value: unknown): value is VanOperationMode =>
+  typeof value === "string" && vanOperationModeValues.has(value);
 
 interface Props {
   match: any;
@@ -73,10 +87,10 @@ class AdminExternalSystems extends Component<Props, State> {
     editingExternalSystem: undefined,
     externalSystem: {
       name: "",
-      type: ExternalSystemType.VAN,
+      type: ExternalSystemType.Van,
       username: "",
       apiKey: "",
-      operationMode: VanOperationMode.VOTERFILE
+      operationMode: VanOperationMode.Voterfile
     },
     syncInitiatedForId: undefined,
     error: undefined
@@ -117,10 +131,10 @@ class AdminExternalSystems extends Component<Props, State> {
       editingExternalSystem: undefined,
       externalSystem: {
         name: "",
-        type: ExternalSystemType.VAN,
+        type: ExternalSystemType.Van,
         username: "",
         apiKey: "",
-        operationMode: VanOperationMode.VOTERFILE
+        operationMode: VanOperationMode.Voterfile
       }
     });
 
@@ -143,21 +157,31 @@ class AdminExternalSystems extends Component<Props, State> {
   };
 
   editExternalSystemProp = (prop: keyof ExternalSystemInput) => (
-    _: unknown,
-    newVal: string
+    event: React.ChangeEvent<HTMLInputElement>
   ) =>
     this.setState((prevState) => ({
-      externalSystem: { ...prevState.externalSystem, ...{ [prop]: newVal } }
+      externalSystem: {
+        ...prevState.externalSystem,
+        [prop]: event.target.value
+      }
     }));
 
+  handleSelectSystemType = (event: React.ChangeEvent<{ value: unknown }>) => {
+    const { value } = event.target;
+    if (!isExternalSystemType(value)) return;
+    this.setState({
+      externalSystem: { ...this.state.externalSystem, type: value }
+    });
+  };
+
   handleSelectOperationMode = (
-    _event: any,
-    _index: number,
-    newOperationMode: VanOperationMode
+    event: React.ChangeEvent<{ value: unknown }>
   ) => {
+    const { value } = event.target;
+    if (!isVanOperationMode(value)) return;
     const { externalSystem } = this.state;
     this.setState({
-      externalSystem: { ...externalSystem, operationMode: newOperationMode }
+      externalSystem: { ...externalSystem, operationMode: value }
     });
   };
 
@@ -282,22 +306,35 @@ class AdminExternalSystems extends Component<Props, State> {
               value={name}
               onChange={this.editExternalSystemProp("name")}
             />
-            <SelectField floatingLabelText="System Type" value={type} fullWidth>
-              {EXTERNAL_SYSTEM_OPTS.map(([display, val]) => (
-                <MenuItem key={val} value={val} primaryText={display} />
-              ))}
-            </SelectField>
-            {type === "VAN" && (
-              <SelectField
-                floatingLabelText="VAN Operation Mode"
-                fullWidth
-                value={operationMode}
-                onChange={this.handleSelectOperationMode}
+            <FormControl fullWidth variant="outlined" size="small">
+              <InputLabel shrink>System Type</InputLabel>
+              <Select
+                value={type}
+                label="System Type"
+                onChange={this.handleSelectSystemType}
               >
-                {OPERATION_MODE_OPTS.map(([display, val]) => (
-                  <MenuItem key={val} value={val} primaryText={display} />
+                {EXTERNAL_SYSTEM_OPTS.map(([display, val]) => (
+                  <MenuItem key={val} value={val}>
+                    {display}
+                  </MenuItem>
                 ))}
-              </SelectField>
+              </Select>
+            </FormControl>
+            {type === "VAN" && (
+              <FormControl fullWidth variant="outlined" size="small">
+                <InputLabel shrink>VAN Operation Mode</InputLabel>
+                <Select
+                  value={operationMode}
+                  label="VAN Operation Mode"
+                  onChange={this.handleSelectOperationMode}
+                >
+                  {OPERATION_MODE_OPTS.map(([display, val]) => (
+                    <MenuItem key={val} value={val}>
+                      {display}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
             )}
             <TextField
               name="username"

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -7,9 +7,17 @@ import ChevronLeft from "@material-ui/icons/ChevronLeft";
 import ChevronRight from "@material-ui/icons/ChevronRight";
 import CloseIcon from "@material-ui/icons/Close";
 import type { ConversationInfoFragment } from "@spoke/spoke-codegen";
+import {
+  useGetCampaignVariablesLazyQuery,
+  useGetCurrentUserProfileLazyQuery
+} from "@spoke/spoke-codegen";
 import { css, StyleSheet } from "aphrodite";
-import React from "react";
+import React, { useState } from "react";
 
+import {
+  applyScript,
+  customFieldsJsonStringToArray
+} from "../../../../lib/scripts";
 import MessageColumn from "./MessageColumn";
 import SurveyColumn from "./SurveyColumn";
 
@@ -34,23 +42,59 @@ interface ConversationPreviewBodyProps {
 const ConversationPreviewBody: React.FC<ConversationPreviewBodyProps> = ({
   conversation,
   organizationId
-}) => (
-  <div className={css(columnStyles.container)}>
-    <div className={css(columnStyles.column)}>
-      <MessageColumn
-        conversation={conversation}
-        organizationId={organizationId}
-      />
+}) => {
+  const { contact, campaign } = conversation;
+  const [messageText, setMessageText] = useState("");
+
+  const [getCampaignVariables] = useGetCampaignVariablesLazyQuery();
+  const [getCurrentUserProfile] = useGetCurrentUserProfileLazyQuery();
+
+  const setScriptMessageText = async (script: string) => {
+    const customFields = customFieldsJsonStringToArray(contact.customFields);
+
+    const { data: cvData } = await getCampaignVariables({
+      variables: { campaignId: campaign.id }
+    });
+    const campaignVariables = cvData?.campaign?.campaignVariables ?? [];
+
+    const { data: userData } = await getCurrentUserProfile();
+    const texter = userData?.currentUser;
+
+    if (texter) {
+      setMessageText(
+        applyScript({
+          script,
+          contact,
+          customFields,
+          campaignVariables,
+          texter
+        })
+      );
+    }
+  };
+
+  return (
+    <div className={css(columnStyles.container)}>
+      <div className={css(columnStyles.column)}>
+        <MessageColumn
+          conversation={conversation}
+          organizationId={organizationId}
+          messageText={messageText}
+          onMessageTextChange={setMessageText}
+          onScriptSelected={setScriptMessageText}
+        />
+      </div>
+      <div className={css(columnStyles.column)}>
+        <SurveyColumn
+          contact={conversation.contact}
+          campaign={conversation.campaign}
+          organizationId={organizationId}
+          onScriptSelected={setScriptMessageText}
+        />
+      </div>
     </div>
-    <div className={css(columnStyles.column)}>
-      <SurveyColumn
-        contact={conversation.contact}
-        campaign={conversation.campaign}
-        organizationId={organizationId}
-      />
-    </div>
-  </div>
-);
+  );
+};
 
 interface ConversationPreviewModalProps {
   organizationId: string;

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/index.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/index.tsx
@@ -1,19 +1,11 @@
 import Button from "@material-ui/core/Button";
 import Grid from "@material-ui/core/Grid";
 import type { ConversationInfoFragment } from "@spoke/spoke-codegen";
-import {
-  useGetCampaignVariablesLazyQuery,
-  useGetCurrentUserProfileLazyQuery,
-  useGetMessageReviewContactUpdatesQuery
-} from "@spoke/spoke-codegen";
+import { useGetMessageReviewContactUpdatesQuery } from "@spoke/spoke-codegen";
 import isNil from "lodash/isNil";
 import React, { useCallback, useState } from "react";
 
 import CannedResponseMenu from "../../../../../components/CannedResponseMenu";
-import {
-  applyScript,
-  customFieldsJsonStringToArray
-} from "../../../../../lib/scripts";
 import MessageList from "./MessageList";
 import MessageOptOut from "./MessageOptOut";
 import MessageResponse from "./MessageResponse";
@@ -31,13 +23,21 @@ type ClickButtonHandler = React.MouseEventHandler<HTMLButtonElement>;
 interface Props {
   organizationId: string;
   conversation: ConversationInfoFragment;
+  messageText: string;
+  onMessageTextChange: (text: string) => void;
+  onScriptSelected: (script: string) => void;
 }
 
 const MessageColumn: React.FC<Props> = (props) => {
-  const { organizationId, conversation } = props;
-  const { contact, campaign } = conversation;
+  const {
+    organizationId,
+    conversation,
+    messageText,
+    onMessageTextChange,
+    onScriptSelected
+  } = props;
+  const { contact } = conversation;
 
-  const [messageText, setMessageText] = useState("");
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
   const { data: updatedContactData } = useGetMessageReviewContactUpdatesQuery({
@@ -48,9 +48,6 @@ const MessageColumn: React.FC<Props> = (props) => {
   const messages = updatedContact?.messages ?? contact.messages;
   const isOptedOut = !isNil(updatedContact?.optOut?.cell);
 
-  const [getCampaignVariables] = useGetCampaignVariablesLazyQuery();
-  const [getCurrentUserProfile] = useGetCurrentUserProfileLazyQuery();
-
   const handleOpenCannedResponse: ClickButtonHandler = useCallback(
     (event) => {
       setAnchorEl(event.currentTarget);
@@ -58,37 +55,12 @@ const MessageColumn: React.FC<Props> = (props) => {
     [setAnchorEl]
   );
 
-  const setScriptMessageText = async (script: string) => {
-    const customFields = customFieldsJsonStringToArray(contact.customFields);
-
-    const { data: cvData } = await getCampaignVariables({
-      variables: {
-        campaignId: campaign.id
-      }
-    });
-    const campaignVariables = cvData?.campaign?.campaignVariables ?? [];
-
-    const { data: userData } = await getCurrentUserProfile();
-    const texter = userData?.currentUser;
-
-    if (texter) {
-      const appliedScript = applyScript({
-        script,
-        contact,
-        customFields,
-        campaignVariables,
-        texter
-      });
-      setMessageText(appliedScript);
-    }
-  };
-
   const handleScriptSelected = useCallback(
     (script: string) => {
       setAnchorEl(null);
-      setScriptMessageText(script);
+      onScriptSelected(script);
     },
-    [setAnchorEl]
+    [setAnchorEl, onScriptSelected]
   );
 
   const handleRequestClose = useCallback(() => setAnchorEl(null), [
@@ -104,7 +76,7 @@ const MessageColumn: React.FC<Props> = (props) => {
           <MessageResponse
             value={messageText}
             conversation={conversation}
-            onChange={setMessageText}
+            onChange={onMessageTextChange}
           />
         )}
         <Grid container spacing={2} justify="flex-end">

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.tsx
@@ -6,13 +6,15 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import type {
+  Campaign,
+  CampaignContact,
+  InteractionStep
+} from "@spoke/spoke-codegen";
 import MenuItem from "material-ui/MenuItem";
 import SelectField from "material-ui/SelectField";
 import React, { useEffect, useState } from "react";
 
-import type { Campaign } from "../../../../../api/campaign";
-import type { CampaignContact } from "../../../../../api/campaign-contact";
-import type { InteractionStep } from "../../../../../api/interaction-step";
 import LoadingIndicator from "../../../../../components/LoadingIndicator";
 import type { MutationMap, QueryMap } from "../../../../../network/types";
 import {
@@ -44,11 +46,13 @@ export interface ManageSurveyResponsesProps {
   campaign: Pick<Campaign, "interactionSteps">;
   contact: CampaignContact;
   mutations: Mutations;
+  onScriptSelected?: (script: string) => void;
 }
 
 export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
   props
 ) => {
+  const { onScriptSelected } = props;
   const [isMakingRequest, setIsMakingRequest] = useState(false);
   const [requestError, setRequestError] = useState("");
   const [questionResponses, setQuestionResponses] = useState<
@@ -57,36 +61,42 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
 
   useEffect(() => {
     const { interactionSteps } = props.campaign;
-    const newQuestionResponses = interactionSteps.reduce<QuestionResponseMap>(
+    const newQuestionResponses = interactionSteps?.reduce<QuestionResponseMap>(
       (collector, iStep) => {
-        return iStep.questionResponse
-          ? { ...collector, [iStep.id]: iStep.questionResponse.value }
-          : collector;
+        if (!iStep) return collector;
+        const value = iStep.questionResponse?.value;
+        return value ? { ...collector, [iStep.id]: value } : collector;
       },
       {}
     );
-    setQuestionResponses(newQuestionResponses);
+    setQuestionResponses(newQuestionResponses ?? {});
   }, [props.campaign.interactionSteps]);
 
   const getResponsesFrom = (startingStepId: string) => {
     const { interactionSteps } = props.campaign;
-
     const iSteps: (InteractionStep & { children: InteractionStep[] })[] = [];
+
     let currentStep: InteractionStep | null =
-      interactionSteps.find(
-        (iStep) => iStep.questionText && iStep.id === startingStepId
+      interactionSteps?.find(
+        (iStep) => iStep?.questionText && iStep.id === startingStepId
       ) ?? null;
+
     while (currentStep) {
       const currentStepId = currentStep.id;
-      const children = interactionSteps.filter(
-        (iStep) => iStep.parentInteractionId === currentStepId
-      );
+
+      const children = (
+        interactionSteps?.filter(
+          (iStep) => iStep?.parentInteractionId === currentStepId
+        ) ?? []
+      ).filter((iStep): iStep is InteractionStep => iStep !== null);
+
       iSteps.push({ ...currentStep, children });
       const value = questionResponses[currentStep.id];
+
       currentStep = value
         ? // Only show actionable questions
-          children.find(
-            (iStep) => iStep.questionText && iStep.answerOption === value
+          children?.find(
+            (iStep) => iStep?.questionText && iStep.answerOption === value
           ) ?? null
         : null;
     }
@@ -133,17 +143,28 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
             interactionStepId: iStepId,
             value
           };
+
           const response = await updateQuestionResponses([input], contact.id);
           if (response.errors) throw response.errors;
+
           updatedQuestionResponses =
             updatedQuestionResponses ?? questionResponses;
           setQuestionResponses({
             ...updatedQuestionResponses,
             [iStepId]: value
           });
+
+          if (onScriptSelected) {
+            const matchingChild = affectedSteps[0]?.children.find(
+              (c: any) => c.answerOption === value
+            );
+            const script = (matchingChild as any)?.scriptOptions?.[0];
+            if (script) onScriptSelected(script);
+          }
         }
       } catch (error) {
-        setRequestError(formatErrorMessage(error.message));
+        const message = error instanceof Error ? error.message : String(error);
+        setRequestError(formatErrorMessage(message));
         setQuestionResponses(initialQuestionResponses);
       } finally {
         setIsMakingRequest(false);
@@ -157,8 +178,8 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
 
   const { interactionSteps } = props.campaign;
 
-  const startingStep = interactionSteps.find(
-    (iStep) => iStep.parentInteractionId === null
+  const startingStep = interactionSteps?.find(
+    (iStep) => iStep?.parentInteractionId === null
   );
 
   // There may not be an interaction step, or it may not define a question
@@ -213,13 +234,14 @@ export interface WrapperProps {
   campaign: Campaign;
   contact: CampaignContact;
   mutations: Mutations;
+  onScriptSelected?: (script: string) => void;
   surveyQuestions: {
     campaign: Pick<Campaign, "id" | "interactionSteps">;
   } & ApolloQueryResult<unknown>;
 }
 
 const ManageSurveyResponsesWrapper: React.FC<WrapperProps> = (props) => {
-  const { surveyQuestions, mutations, contact } = props;
+  const { surveyQuestions, mutations, contact, onScriptSelected } = props;
   return (
     <div>
       <h2>Survey Responses</h2>
@@ -232,6 +254,7 @@ const ManageSurveyResponsesWrapper: React.FC<WrapperProps> = (props) => {
           campaign={surveyQuestions.campaign}
           contact={contact}
           mutations={mutations}
+          onScriptSelected={onScriptSelected}
         />
       )}
     </div>
@@ -251,6 +274,7 @@ const queries: QueryMap<WrapperProps> = {
             parentInteractionId
             isDeleted
             answerActions
+            scriptOptions
 
             questionResponse(campaignContactId: $contactId) {
               id

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
@@ -24,10 +24,11 @@ interface Props {
   organizationId: string;
   campaign: any;
   contact: any;
+  onScriptSelected?: (script: string) => void;
 }
 
 const SurveyColumn: React.FC<Props> = (props) => {
-  const { campaign, contact, organizationId } = props;
+  const { campaign, contact, organizationId, onScriptSelected } = props;
 
   const [isWorking, setIsWorking] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
@@ -67,7 +68,11 @@ const SurveyColumn: React.FC<Props> = (props) => {
   return (
     <div style={styles.container}>
       <ShowTags tags={formattedTags} />
-      <ManageSurveyResponses contact={contact} campaign={campaign} />
+      <ManageSurveyResponses
+        contact={contact}
+        campaign={campaign}
+        onScriptSelected={onScriptSelected}
+      />
       <div style={styles.spacer} />
       <div style={{ display: "flex" }}>
         <div style={styles.spacer} />

--- a/src/containers/AdminTemplateCampaigns/index.tsx
+++ b/src/containers/AdminTemplateCampaigns/index.tsx
@@ -11,6 +11,7 @@ import {
 import React, { useCallback } from "react";
 import { useHistory, useParams } from "react-router-dom";
 
+import spokeTheme from "../../styles/theme";
 import TemplateCampaignRow from "./components/TemplateCampaignRow";
 
 const useStyles = makeStyles((theme) => ({
@@ -18,11 +19,6 @@ const useStyles = makeStyles((theme) => ({
     "& > *": {
       margin: theme.spacing(1)
     }
-  },
-  fab: {
-    position: "absolute",
-    bottom: theme.spacing(2),
-    right: theme.spacing(2)
   }
 }));
 
@@ -105,7 +101,7 @@ export const AdminTemplateCampaigns: React.FC = () => {
       </div>
       <Fab
         color="primary"
-        className={classes.fab}
+        style={spokeTheme.components.floatingButton}
         aria-label="add"
         disabled={createTemplateLoading}
         onClick={handleClickCreateTemplate}

--- a/src/containers/Login/index.tsx
+++ b/src/containers/Login/index.tsx
@@ -23,7 +23,6 @@ const styles = StyleSheet.create({
     "align-items": "center",
     flexDirection: "column",
     height: "100vh",
-    "padding-top": "10vh",
     background: theme.colors.veryLightGray
   },
   button: {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,6 +15,9 @@ interface Window {
   BASE_URL: string;
   ENABLE_TROLLBOT: boolean;
 
+  CHATWOOT_WEBSITE_TOKEN?: string;
+  CHATWOOT_BASE_URL?: string;
+
   AuthService: any;
 }
 

--- a/src/lib/correlation-id.ts
+++ b/src/lib/correlation-id.ts
@@ -1,0 +1,36 @@
+import { randomUUID } from "crypto";
+import type { NextFunction, Request, Response } from "express";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Locals {
+      requestId: string | undefined;
+    }
+  }
+}
+
+const REQUEST_ID_HEADER = "X-Request-Id";
+
+/**
+ * Express middleware that assigns a unique requestId to every inbound request.
+ *
+ * - If the upstream caller supplies an X-Request-Id header, that value is
+ *   reused so the correlation ID flows across service boundaries.
+ * - Otherwise a new random ID is generated via crypto.randomUUID().
+ *
+ * The ID is stored on res.locals.requestId so that downstream middleware,
+ * GraphQL resolvers, and worker tasks can attach it to log entries.
+ * It is also echoed back in the X-Request-Id response header so callers
+ * can correlate requests in their own logs.
+ */
+const correlationId = (req: Request, res: Response, next: NextFunction) => {
+  const headerId = req.headers[REQUEST_ID_HEADER.toLowerCase()];
+  const requestId = typeof headerId === "string" ? headerId : randomUUID();
+
+  res.locals.requestId = requestId;
+  res.setHeader(REQUEST_ID_HEADER, requestId);
+  next();
+};
+
+export default correlationId;

--- a/src/lib/request-logging.js
+++ b/src/lib/request-logging.js
@@ -1,25 +1,18 @@
 import expressWinston from "express-winston";
-import winston from "winston";
 
-import { config } from "../config";
+import logger from "../logger";
 
 expressWinston.requestWhitelist.push("body");
 
 export default expressWinston.logger({
-  transports: [
-    config.LOGGING_MONGODB_URI
-      ? new winston.transports.MongoDB({
-          db: config.LOGGING_MONGODB_URI
-        })
-      : new winston.transports.Console()
-  ],
-  format: winston.format.combine(
-    winston.format.colorize(),
-    winston.format.json()
-  ),
-  meta: true, // optional: control whether you want to log the meta data about the request (default to true)
-  msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
-  expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true
-  colorize: false, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
-  ignoreRoute: (_req, _res) => false // optional: allows to skip some log messages based on request and/or response
+  winstonInstance: logger,
+  meta: true,
+  msg: "HTTP {{req.method}} {{req.url}}",
+  expressFormat: true,
+  colorize: false,
+  ignoreRoute: (_req, _res) => false,
+  // Attach the correlation ID from the current request to every log line
+  dynamicMeta: (_req, res) => ({
+    requestId: res.locals.requestId
+  })
 });

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,20 @@
 const winston = require("winston");
+const { trace } = require("@opentelemetry/api");
 
 const { config } = require("./config");
+
+// Stamps traceId + spanId onto every log entry when there is an active OTEL span.
+// When OTEL is disabled the global tracer is a no-op and getActiveSpan() returns
+// undefined, so this is always safe to include.
+const traceContextFormat = winston.format((info) => {
+  const span = trace.getActiveSpan();
+  if (span?.isRecording()) {
+    const { traceId, spanId } = span.spanContext();
+    info.traceId = traceId;
+    info.spanId = spanId;
+  }
+  return info;
+})();
 
 // Winston configuration
 const logger = winston.createLogger({
@@ -9,6 +23,7 @@ const logger = winston.createLogger({
     new winston.transports.Console({
       level: config.LOG_LEVEL,
       format: winston.format.combine(
+        traceContextFormat,
         winston.format.timestamp(),
         winston.format.json()
       )
@@ -16,4 +31,22 @@ const logger = winston.createLogger({
   ]
 });
 
+/**
+ * Create a child logger pre-stamped with request/domain context fields.
+ * Every log call on the returned logger will include the provided fields,
+ * making it easy to correlate log lines across a single request or task.
+ *
+ * @param {object} ctx
+ * @param {string} [ctx.requestId]     - Correlation ID for the HTTP request
+ * @param {string} [ctx.userId]        - Authenticated user ID
+ * @param {string} [ctx.organizationId]
+ * @param {string} [ctx.campaignId]
+ *
+ * @example
+ * const log = childLogger({ requestId, userId: user.id });
+ * log.info("sendMessage called", { contactId });
+ */
+const childLogger = (ctx) => logger.child(ctx);
+
 module.exports = logger;
+module.exports.childLogger = childLogger;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,27 @@
+import winston from "winston";
+
+import { config } from "./config";
+
+interface LogContext {
+  requestId?: string;
+  userId?: string;
+  organizationId?: string;
+  campaignId?: string;
+}
+
+const logger = winston.createLogger({
+  exitOnError: false,
+  transports: [
+    new winston.transports.Console({
+      level: config.LOG_LEVEL,
+      format: winston.format.combine(
+        winston.format.timestamp(),
+        winston.format.json()
+      )
+    })
+  ]
+});
+
+export const childLogger = (ctx: LogContext) => logger.child(ctx);
+
+export default logger;

--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -8,6 +8,7 @@ import { getMessageType } from "../../../lib/scripts";
 import { stringIsAValidUrl } from "../../../lib/utils";
 import logger from "../../../logger";
 import { makeNumbersClient } from "../../lib/assemble-numbers";
+import { smsSendTotal } from "../../metrics";
 import { r } from "../../models";
 import { errToObj } from "../../utils";
 import { getOrgFeature } from "../organization-settings";
@@ -223,9 +224,11 @@ export const sendMessage = async (
         service_response: JSON.stringify([result])
       })
       .where({ id: spokeMessageId });
+    smsSendTotal.inc({ status: "success", provider: "switchboard" });
   } catch (exc) {
     // TODO - distinguish different failures modes (HTTP failure vs. HTTP 200 with GraphQL errors)
 
+    smsSendTotal.inc({ status: "error", provider: "switchboard" });
     logger.error("Error sending message with Assemble Numbers: ", {
       ...errToObj(exc),
       messageInput

--- a/src/server/api/lib/fakeservice.js
+++ b/src/server/api/lib/fakeservice.js
@@ -1,3 +1,4 @@
+import { smsSendTotal } from "../../metrics";
 import { r } from "../../models";
 // eslint-disable-next-line import/named
 import { getLastMessage } from "./message-sending";
@@ -6,8 +7,9 @@ import { getLastMessage } from "./message-sending";
 // that end up just in the db appropriately and then using sendReply() graphql
 // queries for the reception (rather than a real service)
 
-const sendMessage = async (message, _organizationId, _trx) =>
-  r
+const sendMessage = async (message, _organizationId, _trx) => {
+  smsSendTotal.inc({ status: "success", provider: "fakeservice" });
+  return r
     .knex("message")
     .update({
       send_status: "SENT",
@@ -15,6 +17,7 @@ const sendMessage = async (message, _organizationId, _trx) =>
       sent_at: r.knex.fn.now()
     })
     .where({ id: message.id });
+};
 
 // None of the rest of this is even used for fake-service
 // but *would* be used if it was actually an outside service.

--- a/src/server/api/lib/nexmo.js
+++ b/src/server/api/lib/nexmo.js
@@ -3,6 +3,7 @@ import Nexmo from "nexmo";
 import { config } from "../../../config";
 import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import logger from "../../../logger";
+import { smsSendTotal } from "../../metrics";
 import { r } from "../../models";
 // eslint-disable-next-line import/named
 import { appendServiceResponse, getLastMessage } from "./message-sending";
@@ -128,6 +129,7 @@ const sendMessage = async (message, trx = r.knex) => {
         messageToSave.service = "nexmo";
 
         if (hasError) {
+          smsSendTotal.inc({ status: "error", provider: "nexmo" });
           if (messageToSave.service_messages.length >= MAX_SEND_ATTEMPTS) {
             messageToSave.send_status = "ERROR";
           }
@@ -144,6 +146,7 @@ const sendMessage = async (message, trx = r.knex) => {
               )
             );
         } else {
+          smsSendTotal.inc({ status: "success", provider: "nexmo" });
           const { id: messageId, ...messagePayload } = message;
           trx("message")
             .update({ ...messagePayload, send_status: "SENT" })

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -5,6 +5,7 @@ import { config } from "../../../config";
 import { DateTime } from "../../../lib/datetime";
 import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import logger from "../../../logger";
+import { smsSendTotal } from "../../metrics";
 import { r } from "../../models";
 import { MessagingServiceType } from "../types";
 import { symmetricDecrypt } from "./crypto";
@@ -259,6 +260,7 @@ const sendMessage = async (message, organizationId, trx = r.knex) => {
       }
 
       if (hasError) {
+        smsSendTotal.inc({ status: "error", provider: "twilio" });
         const SENT_STRING = '"status"'; // will appear in responses
         if (
           messageToSave.service_response.split(SENT_STRING).length >=
@@ -279,6 +281,7 @@ const sendMessage = async (message, organizationId, trx = r.knex) => {
             )
           );
       } else {
+        smsSendTotal.inc({ status: "success", provider: "twilio" });
         const { id: messageId, ...updatePayload } = messageToSave;
         trx("message")
           .update({

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -9,6 +9,7 @@ import basicAuth from "express-basic-auth";
 import expressSession from "express-session";
 
 import { config } from "../config";
+import correlationId from "../lib/correlation-id";
 import requestLogging from "../lib/request-logging";
 import logger from "../logger";
 import { fulfillPendingRequestFor } from "./api/assignment";
@@ -66,9 +67,9 @@ export const createApp = async () => {
     next();
   });
 
-  if (config.LOG_LEVEL === "verbose" || config.LOG_LEVEL === "debug") {
-    app.use(requestLogging);
-  }
+  // Assign a correlation ID to every request before anything else logs
+  app.use(correlationId);
+  app.use(requestLogging);
 
   // Send version to client
   if (config.SPOKE_VERSION) {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -13,6 +13,7 @@ import requestLogging from "../lib/request-logging";
 import logger from "../logger";
 import { fulfillPendingRequestFor } from "./api/assignment";
 import pgPool from "./db";
+import { httpRequestDuration, httpRequestsTotal, registry } from "./metrics";
 import appRenderer from "./middleware/app-renderer";
 import { userLoggedIn } from "./models/cacheable_queries";
 import {
@@ -36,6 +37,34 @@ const {
 
 export const createApp = async () => {
   const app = express();
+
+  // Prometheus metrics endpoint — must be before the HTTP instrumentation
+  // middleware so the /metrics route itself isn't double-counted
+  if (config.METRICS_ENABLED) {
+    app.get("/metrics", async (_req, res) => {
+      res.set("Content-Type", registry.contentType);
+      res.end(await registry.metrics());
+    });
+  }
+
+  // Instrument every request: record duration and total count by method/route/status
+  app.use((req, res, next) => {
+    const startNs = process.hrtime.bigint();
+    res.on("finish", () => {
+      const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
+      // req.route.path gives the matched route pattern (e.g. "/graphql"),
+      // avoiding high-cardinality labels from path params like IDs
+      const route = (req.route?.path as string | undefined) ?? "unmatched";
+      const labels = {
+        method: req.method,
+        route,
+        status_code: String(res.statusCode)
+      };
+      httpRequestDuration.observe(labels, durationSeconds);
+      httpRequestsTotal.inc(labels);
+    });
+    next();
+  });
 
   if (config.LOG_LEVEL === "verbose" || config.LOG_LEVEL === "debug") {
     app.use(requestLogging);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -54,7 +54,7 @@ export const createApp = async () => {
       const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
       // req.route.path gives the matched route pattern (e.g. "/graphql"),
       // avoiding high-cardinality labels from path params like IDs
-      const route = (req.route?.path as string | undefined) ?? "unmatched";
+      const route: string = req.route?.path ?? "unmatched";
       const labels = {
         method: req.method,
         route,

--- a/src/server/auth-passport/auth0.ts
+++ b/src/server/auth-passport/auth0.ts
@@ -6,6 +6,7 @@ import { config } from "../../config";
 import logger from "../../logger";
 import { capitalizeWord } from "../api/lib/utils";
 import { contextForRequest } from "../contexts";
+import { authAttemptsTotal } from "../metrics";
 import type { SpokeRequest } from "../types";
 import type { PassportCallback, UserWithStatus } from "./util";
 import { passportCallback } from "./util";
@@ -31,6 +32,7 @@ export const setupAuth0Passport = () => {
     ) => {
       const auth0Id = auth0User.id ?? auth0User._json.sub;
       if (!auth0Id) {
+        authAttemptsTotal.inc({ strategy: "auth0", status: "failure" });
         return done(new Error("Null user in Auth0 login callback"));
       }
 
@@ -43,10 +45,12 @@ export const setupAuth0Passport = () => {
           .where({ auth0_id: auth0Id })
           .first();
         if (spokeUser) {
+          authAttemptsTotal.inc({ strategy: "auth0", status: "success" });
           return done(null, spokeUser);
         }
       } catch (err: any) {
         logger.error("Auth0 login error: could not find existing user: ", err);
+        authAttemptsTotal.inc({ strategy: "auth0", status: "failure" });
         return done(err);
       }
 
@@ -69,9 +73,11 @@ export const setupAuth0Passport = () => {
           .insert(userData)
           .returning("*")
           .then(([user]) => ({ ...user, isNew: true }));
+        authAttemptsTotal.inc({ strategy: "auth0", status: "success" });
         return done(null, spokeUser);
       } catch (err: any) {
         logger.error("Error creating new Auth0 user: ", err);
+        authAttemptsTotal.inc({ strategy: "auth0", status: "failure" });
         return done(err);
       }
     }

--- a/src/server/auth-passport/local.ts
+++ b/src/server/auth-passport/local.ts
@@ -11,6 +11,7 @@ import localAuthHelpers, {
   LocalAuthError
 } from "../local-auth-helpers";
 import sendEmail from "../mail";
+import { authAttemptsTotal } from "../metrics";
 import { r } from "../models";
 import type { SpokeRequest } from "../types";
 import type { PassportCallback, UserWithStatus } from "./util";
@@ -61,8 +62,10 @@ export const setupLocalAuthPassport = () => {
         if (authType === "signup") {
           user.isNew = true;
         }
+        authAttemptsTotal.inc({ strategy: "local", status: "success" });
         return done(null, user);
       } catch (error: any) {
+        authAttemptsTotal.inc({ strategy: "local", status: "failure" });
         return done(error);
       }
     }

--- a/src/server/auth-passport/slack.ts
+++ b/src/server/auth-passport/slack.ts
@@ -6,6 +6,7 @@ import { config } from "../../config";
 import logger from "../../logger";
 import { contextForRequest } from "../contexts";
 import { botClient } from "../lib/slack";
+import { authAttemptsTotal } from "../metrics";
 import type { SpokeRequest } from "../types";
 import { errToObj } from "../utils";
 import type { PassportCallback, UserWithStatus } from "./util";
@@ -88,10 +89,12 @@ export const setupSlackPassport = () => {
           .where({ auth0_id: slackUser.id })
           .first();
         if (spokeUser) {
+          authAttemptsTotal.inc({ strategy: "slack", status: "success" });
           return done(null, spokeUser);
         }
       } catch (err: any) {
         logger.error("Slack login error: could not find existing user: ", err);
+        authAttemptsTotal.inc({ strategy: "slack", status: "failure" });
         return done(err);
       }
 
@@ -103,10 +106,12 @@ export const setupSlackPassport = () => {
             .where({ email: slackUser.email })
             .returning("*");
           if (spokeUser) {
+            authAttemptsTotal.inc({ strategy: "slack", status: "success" });
             return done(null, spokeUser);
           }
         } catch (err: any) {
           logger.error("Error converting existing Slack user: ", err);
+          authAttemptsTotal.inc({ strategy: "slack", status: "failure" });
           return done(err);
         }
       }
@@ -131,9 +136,11 @@ export const setupSlackPassport = () => {
             logger.error("Slack login error: could not insert new user: ", err);
             throw err;
           });
+        authAttemptsTotal.inc({ strategy: "slack", status: "success" });
         return done(null, spokeUser);
       } catch (err: any) {
         logger.error("Error creating new Slack user: ", err);
+        authAttemptsTotal.inc({ strategy: "slack", status: "failure" });
         return done(err);
       }
     }

--- a/src/server/contexts/index.ts
+++ b/src/server/contexts/index.ts
@@ -41,6 +41,7 @@ export const contextForRequest = async (
   return {
     user: (<Request & { user: any }>req).user,
     loaders: createLoaders(hostContext),
+    requestId: req.res?.locals.requestId,
     ...hostContext
   };
 };

--- a/src/server/contexts/types.ts
+++ b/src/server/contexts/types.ts
@@ -15,4 +15,6 @@ export interface SpokeContext {
 export interface SpokeRequestContext extends SpokeContext {
   user: any;
   loaders: any;
+  /** Correlation ID for the current HTTP request, set by the correlationId middleware. */
+  requestId: string | undefined;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,3 +1,5 @@
+import "./tracing"; // must be first — patches express, pg, http before they load
+
 import type { Knex } from "knex";
 import { createLightship } from "lightship";
 import cron from "node-cron";

--- a/src/server/knex.js
+++ b/src/server/knex.js
@@ -1,5 +1,5 @@
 const { config } = require("../config");
-const logger = require("../logger");
+const logger = require("../logger").default;
 
 // Define a Knex connection. Currently, this is used only to instantiate the
 // rethink-knex-adapter's connection. In the future, if the adapter is

--- a/src/server/lib/templates/pages/campaign-preview/index.tsx
+++ b/src/server/lib/templates/pages/campaign-preview/index.tsx
@@ -115,8 +115,10 @@ const InteractionStep: React.FC<InteractionStepProps> = ({
       )}
       {childSteps && (
         <>
-          <i className="bi bi-chevron-down" />
-          <i className="bi bi-chevron-up" />
+          <span className="chevron-toggle">
+            <i className="bi bi-chevron-down" />
+            <i className="bi bi-chevron-up" />
+          </span>
           <ul>
             {childSteps.map((childStep) => (
               <InteractionStep
@@ -247,32 +249,39 @@ export const renderCampaignPreview = (
           li.collapsed ul {
             display: none;
           }
-          li.interaction-step > i.bi-chevron-down {
+          .chevron-toggle {
+            cursor: pointer;
+            display: inline-block;
+          }
+          .chevron-toggle > i.bi-chevron-down {
             display: none;
           }
-          li.collapsed > i.bi-chevron-up {
+          li.collapsed > .chevron-toggle > i.bi-chevron-up {
             display: none;
           }
-          li.collapsed > i.bi-chevron-down {
+          li.collapsed > .chevron-toggle > i.bi-chevron-down {
             display: inline !important;
           }
-          .no-children i.bi {
+          .no-children .chevron-toggle {
             display: none !important;
+          }
+          .interaction-step > p {
+            pointer-events: none;
           }
           .script {
             font-style: italic;
             white-space: pre-wrap;
           }
-          html{background-color:#fefefe}body{font-family:Open Sans,Arial;color:#454545;font-size:16px;margin:2em auto;max-width:800px;padding:1em;line-height:1.4;text-align:justify}html.contrast body{color:#050505}html.contrast blockquote{color:#11151a}html.contrast blockquote:before{color:#262626}html.contrast a{color:#0051c9}html.contrast a:visited{color:#7d013e}html.contrast span.wr{color:#800}html.contrast span.mfw{color:#4d0000}html.inverted{background-color:#010101}html.inverted body{color:#bababa}html.inverted div#contrast,html.inverted div#invmode{color:#fff;background-color:#000}html.inverted blockquote{color:#dad0c7}html.inverted blockquote:before{color:#bfbfbf}html.inverted a{color:#07a}html.inverted a:visited{color:#ac5a82}html.inverted span.wr{color:#c0392b}html.inverted span.mfw{color:#8a0000}html.inverted.contrast{background-color:#010101}html.inverted.contrast body{color:#fff}html.inverted.contrast div#contrast,html.inverted.contrast div#invmode{color:#fff;background-color:#000}html.inverted.contrast blockquote{color:#f8f6f5}html.inverted.contrast blockquote:before{color:#e5e5e5}html.inverted.contrast a{color:#07a}html.inverted.contrast a:visited{color:#ac5a82}html.inverted.contrast span.wr{color:#c0392b}html.inverted.contrast span.mfw{color:#a10000}a{color:#07a}a:visited{color:#941352}.noselect{-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}span.citneed{vertical-align:top;font-size:.7em;padding-left:.3em}small{font-size:.4em}p.st{margin-top:-1em}div.fancyPositioning div.picture-left{float:left;width:40%;overflow:hidden;margin-right:1em}div.fancyPositioning div.picture-left img{width:100%}div.fancyPositioning div.picture-left p.caption{font-size:.7em}div.fancyPositioning div.tleft{float:left;width:55%}div.fancyPositioning div.tleft p:first-child{margin-top:0}div.fancyPositioning:after{display:block;content:"";clear:both}ul li img{height:1em}blockquote{color:#456;margin-left:0;margin-top:2em;margin-bottom:2em}blockquote span{float:left;margin-left:1rem;padding-top:1rem}blockquote author{display:block;clear:both;font-size:.6em;margin-left:2.4rem;font-style:oblique}blockquote author:before{content:"- ";margin-right:1em}blockquote:before{font-family:Times New Roman,Times,Arial;color:#666;content:open-quote;font-size:2.2em;font-weight:600;float:left;margin-top:0;margin-right:.2rem;width:1.2rem}blockquote:after{content:"";display:block;clear:both}@media screen and (max-width:500px){body{text-align:left}div.fancyPositioning div.picture-left,div.fancyPositioning div.tleft{float:none;width:inherit}blockquote span{width:80%}blockquote author{padding-top:1em;width:80%;margin-left:15%}blockquote author:before{content:"";margin-right:inherit}}span.visited{color:#941352}span.visited-maroon{color:#85144b}span.wr{color:#c0392b;font-weight:600;text-decoration:underline}div#contrast{color:#000;top:10px}div#contrast,div#invmode{cursor:pointer;position:absolute;right:10px;font-size:.8em;text-decoration:underline;-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}div#invmode{color:#fff;background-color:#000;top:34px;padding:2px 5px}span.sb{color:#00e}span.sb,span.sv{cursor:not-allowed}span.sv{color:#551a8b}span.foufoufou{color:#444;font-weight:700}span.foufoufou:before{content:"";display:inline-block;width:1em;height:1em;margin-left:.2em;margin-right:.2em;background-color:#444}span.foufivfoufivfoufiv{color:#454545;font-weight:700}span.foufivfoufivfoufiv:before{content:"";display:inline-block;width:1em;height:1em;margin-left:.2em;margin-right:.2em;background-color:#454545}span.mfw{color:#730000}a.kopimi,a.kopimi img.kopimi{display:block;margin-left:auto;margin-right:auto}a.kopimi img.kopimi{height:2em}p.fakepre{font-family:monospace;font-size:.9em}
+          html{background-color:#fefefe}body{font-family:Open Sans,Arial;color:#454545;font-size:16px;margin:2em auto;max-width:800px;padding:1em;line-height:1.4}html.contrast body{color:#050505}html.contrast blockquote{color:#11151a}html.contrast blockquote:before{color:#262626}html.contrast a{color:#0051c9}html.contrast a:visited{color:#7d013e}html.contrast span.wr{color:#800}html.contrast span.mfw{color:#4d0000}html.inverted{background-color:#010101}html.inverted body{color:#bababa}html.inverted div#contrast,html.inverted div#invmode{color:#fff;background-color:#000}html.inverted blockquote{color:#dad0c7}html.inverted blockquote:before{color:#bfbfbf}html.inverted a{color:#07a}html.inverted a:visited{color:#ac5a82}html.inverted span.wr{color:#c0392b}html.inverted span.mfw{color:#8a0000}html.inverted.contrast{background-color:#010101}html.inverted.contrast body{color:#fff}html.inverted.contrast div#contrast,html.inverted.contrast div#invmode{color:#fff;background-color:#000}html.inverted.contrast blockquote{color:#f8f6f5}html.inverted.contrast blockquote:before{color:#e5e5e5}html.inverted.contrast a{color:#07a}html.inverted.contrast a:visited{color:#ac5a82}html.inverted.contrast span.wr{color:#c0392b}html.inverted.contrast span.mfw{color:#a10000}a{color:#07a}a:visited{color:#941352}.noselect{-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}span.citneed{vertical-align:top;font-size:.7em;padding-left:.3em}small{font-size:.4em}p.st{margin-top:-1em}div.fancyPositioning div.picture-left{float:left;width:40%;overflow:hidden;margin-right:1em}div.fancyPositioning div.picture-left img{width:100%}div.fancyPositioning div.picture-left p.caption{font-size:.7em}div.fancyPositioning div.tleft{float:left;width:55%}div.fancyPositioning div.tleft p:first-child{margin-top:0}div.fancyPositioning:after{display:block;content:"";clear:both}ul li img{height:1em}blockquote{color:#456;margin-left:0;margin-top:2em;margin-bottom:2em}blockquote span{float:left;margin-left:1rem;padding-top:1rem}blockquote author{display:block;clear:both;font-size:.6em;margin-left:2.4rem;font-style:oblique}blockquote author:before{content:"- ";margin-right:1em}blockquote:before{font-family:Times New Roman,Times,Arial;color:#666;content:open-quote;font-size:2.2em;font-weight:600;float:left;margin-top:0;margin-right:.2rem;width:1.2rem}blockquote:after{content:"";display:block;clear:both}@media screen and (max-width:500px){body{text-align:left}div.fancyPositioning div.picture-left,div.fancyPositioning div.tleft{float:none;width:inherit}blockquote span{width:80%}blockquote author{padding-top:1em;width:80%;margin-left:15%}blockquote author:before{content:"";margin-right:inherit}}span.visited{color:#941352}span.visited-maroon{color:#85144b}span.wr{color:#c0392b;font-weight:600;text-decoration:underline}div#contrast{color:#000;top:10px}div#contrast,div#invmode{cursor:pointer;position:absolute;right:10px;font-size:.8em;text-decoration:underline;-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}div#invmode{color:#fff;background-color:#000;top:34px;padding:2px 5px}span.sb{color:#00e}span.sb,span.sv{cursor:not-allowed}span.sv{color:#551a8b}span.foufoufou{color:#444;font-weight:700}span.foufoufou:before{content:"";display:inline-block;width:1em;height:1em;margin-left:.2em;margin-right:.2em;background-color:#444}span.foufivfoufivfoufiv{color:#454545;font-weight:700}span.foufivfoufivfoufiv:before{content:"";display:inline-block;width:1em;height:1em;margin-left:.2em;margin-right:.2em;background-color:#454545}span.mfw{color:#730000}a.kopimi,a.kopimi img.kopimi{display:block;margin-left:auto;margin-right:auto}a.kopimi img.kopimi{height:2em}p.fakepre{font-family:monospace;font-size:.9em}
         </style>
       </head>
       <body>
         ${campaignPreviewHtml}
       <script>
-        $(".interaction-step.with-children").on('click', function(event){
+        $(".interaction-step.with-children > .chevron-toggle").on('click', function(event){
           event.stopPropagation();
           event.stopImmediatePropagation();
-          $(this).toggleClass("collapsed");
+          $(this).closest(".interaction-step").toggleClass("collapsed");
         });
       </script>
       </body>

--- a/src/server/metrics.ts
+++ b/src/server/metrics.ts
@@ -5,10 +5,7 @@ import {
   Registry
 } from "prom-client";
 
-import { config } from "../config";
-
 export const registry = new Registry();
-registry.setDefaultLabels({ client: config.CLIENT_LABEL });
 
 // Collect Node.js runtime metrics (CPU, memory, event loop lag, GC, etc.)
 collectDefaultMetrics({ register: registry });

--- a/src/server/metrics.ts
+++ b/src/server/metrics.ts
@@ -1,0 +1,75 @@
+import {
+  collectDefaultMetrics,
+  Counter,
+  Histogram,
+  Registry
+} from "prom-client";
+
+import { config } from "../config";
+
+export const registry = new Registry();
+registry.setDefaultLabels({ client: config.CLIENT_LABEL });
+
+// Collect Node.js runtime metrics (CPU, memory, event loop lag, GC, etc.)
+collectDefaultMetrics({ register: registry });
+
+// --- HTTP metrics ---
+
+export const httpRequestDuration = new Histogram({
+  name: "http_request_duration_seconds",
+  help: "Duration of HTTP requests in seconds",
+  labelNames: ["method", "route", "status_code"],
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [registry]
+});
+
+export const httpRequestsTotal = new Counter({
+  name: "http_requests_total",
+  help: "Total number of HTTP requests",
+  labelNames: ["method", "route", "status_code"],
+  registers: [registry]
+});
+
+// --- GraphQL metrics ---
+
+export const graphqlRequestDuration = new Histogram({
+  name: "graphql_request_duration_seconds",
+  help: "Duration of GraphQL requests in seconds",
+  labelNames: ["operation_name", "operation_type"],
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [registry]
+});
+
+export const graphqlErrorsTotal = new Counter({
+  name: "graphql_errors_total",
+  help: "Total number of GraphQL errors",
+  labelNames: ["operation_name", "error_type"],
+  registers: [registry]
+});
+
+// --- SMS metrics ---
+// Incremented by SMS provider integrations. Labels: status (success|error), provider (telnyx|twilio|nexmo)
+
+export const smsSendTotal = new Counter({
+  name: "spoke_sms_send_total",
+  help: "Total number of SMS send attempts",
+  labelNames: ["status", "provider"],
+  registers: [registry]
+});
+
+// --- Worker metrics ---
+
+export const workerTaskDuration = new Histogram({
+  name: "worker_task_duration_seconds",
+  help: "Duration of Graphile Worker task executions in seconds",
+  labelNames: ["task_identifier", "status"],
+  buckets: [0.1, 0.5, 1, 5, 10, 30, 60, 120, 300],
+  registers: [registry]
+});
+
+export const workerTaskTotal = new Counter({
+  name: "worker_task_total",
+  help: "Total number of Graphile Worker task executions",
+  labelNames: ["task_identifier", "status"],
+  registers: [registry]
+});

--- a/src/server/metrics.ts
+++ b/src/server/metrics.ts
@@ -1,11 +1,16 @@
+import type { Knex } from "knex";
 import {
   collectDefaultMetrics,
   Counter,
+  Gauge,
   Histogram,
   Registry
 } from "prom-client";
 
+import { config } from "../config";
+
 export const registry = new Registry();
+registry.setDefaultLabels({ environment: config.DEPLOY_ENVIRONMENT });
 
 // Collect Node.js runtime metrics (CPU, memory, event loop lag, GC, etc.)
 collectDefaultMetrics({ register: registry });
@@ -45,12 +50,21 @@ export const graphqlErrorsTotal = new Counter({
 });
 
 // --- SMS metrics ---
-// Incremented by SMS provider integrations. Labels: status (success|error), provider (telnyx|twilio|nexmo)
+// Incremented by SMS provider integrations. Labels: status (success|error), provider (switchboard|twilio|nexmo)
 
 export const smsSendTotal = new Counter({
   name: "spoke_sms_send_total",
   help: "Total number of SMS send attempts",
   labelNames: ["status", "provider"],
+  registers: [registry]
+});
+
+// --- Auth metrics ---
+
+export const authAttemptsTotal = new Counter({
+  name: "auth_attempts_total",
+  help: "Total number of authentication attempts",
+  labelNames: ["strategy", "status"],
   registers: [registry]
 });
 
@@ -70,3 +84,73 @@ export const workerTaskTotal = new Counter({
   labelNames: ["task_identifier", "status"],
   registers: [registry]
 });
+
+// --- Database metrics ---
+
+export const dbQueryDuration = new Histogram({
+  name: "db_query_duration_seconds",
+  help: "Duration of database queries in seconds",
+  labelNames: ["operation", "db"],
+  buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
+  registers: [registry]
+});
+
+export const dbPoolConnections = new Gauge({
+  name: "db_pool_connections",
+  help: "Current number of database pool connections by state",
+  labelNames: ["db", "state"],
+  registers: [registry]
+});
+
+const detectOperation = (sql: string): string => {
+  const prefix = sql.trimStart().toLowerCase().slice(0, 6);
+  if (prefix === "select") return "select";
+  if (prefix === "insert") return "insert";
+  if (prefix === "update") return "update";
+  if (prefix === "delete") return "delete";
+  return "other";
+};
+
+/**
+ * Attach Knex query-event listeners and a pool-polling interval to feed
+ * db_query_duration_seconds and db_pool_connections for the given instance.
+ */
+export const instrumentKnex = (
+  knexInstance: Knex,
+  label: "primary" | "reader"
+) => {
+  const queryStartTimes = new Map<string, number>();
+
+  knexInstance.on("query", (data: any) => {
+    queryStartTimes.set(data.__knexQueryUid, Date.now());
+  });
+
+  knexInstance.on("query-response", (_response: any, data: any) => {
+    const start = queryStartTimes.get(data.__knexQueryUid);
+    if (start !== undefined) {
+      dbQueryDuration.observe(
+        { operation: detectOperation(data.sql), db: label },
+        (Date.now() - start) / 1000
+      );
+      queryStartTimes.delete(data.__knexQueryUid);
+    }
+  });
+
+  knexInstance.on("query-error", (_error: any, data: any) => {
+    queryStartTimes.delete(data.__knexQueryUid);
+  });
+
+  // tarn.js (Knex's pool) doesn't emit events, so poll every 15 s.
+  // .unref() prevents the interval from keeping the process alive.
+  setInterval(() => {
+    const { pool } = knexInstance.client;
+    if (pool) {
+      dbPoolConnections.set({ db: label, state: "active" }, pool.numUsed());
+      dbPoolConnections.set({ db: label, state: "idle" }, pool.numFree());
+      dbPoolConnections.set(
+        { db: label, state: "pending" },
+        pool.numPendingAcquires()
+      );
+    }
+  }, 15_000).unref();
+};

--- a/src/server/middleware/app-renderer.js
+++ b/src/server/middleware/app-renderer.js
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 
 import { clientConfig, config } from "../../config";
+import { r } from "../models";
 
 // -----------------------------------------
 // Asset Map
@@ -46,6 +47,46 @@ const externalLinks = config.NO_EXTERNAL_LINKS
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.auth0.com/js/lock/11.0.1/lock.min.js"></script>`;
+
+const chatwootBase = config.CHATWOOT_BASE_URL
+  ? String(config.CHATWOOT_BASE_URL).replace(/\/$/, "")
+  : "";
+const chatwootScript =
+  config.CHATWOOT_WEBSITE_TOKEN && chatwootBase
+    ? `
+    <script>
+      (function (d, t) {
+        var BASE_URL = ${JSON.stringify(chatwootBase)};
+        var TOKEN = ${JSON.stringify(config.CHATWOOT_WEBSITE_TOKEN)};
+        window.chatwootSettings = { hideMessageBubble: false };
+        var g = d.createElement(t),
+          s = d.getElementsByTagName(t)[0];
+        g.src = BASE_URL + "/packs/js/sdk.js";
+        g.async = true;
+        s.parentNode.insertBefore(g, s);
+        g.onload = function () {
+          window.chatwootSDK.run({
+            websiteToken: TOKEN,
+            baseUrl: BASE_URL
+          });
+        };
+      })(document, "script");
+    </script>
+  `
+    : "";
+
+const shouldShowChatwoot = async (user) => {
+  if (!chatwootScript || !user) return false;
+  if (user.is_superadmin === true) return true;
+
+  const membership = await r
+    .reader("user_organization")
+    .where({ user_id: user.id })
+    .whereIn("role", ["ADMIN", "OWNER"])
+    .first("id");
+
+  return Boolean(membership);
+};
 
 const rollbarScript = config.ROLLBAR_ACCESS_TOKEN
   ? `
@@ -99,6 +140,7 @@ const indexHtml = `
       ${windowVars.join("      \n")}
     </script>
     ${rollbarScript}
+    ${chatwootScript}
   </head>
   <body>
     <div id="mount"></div>
@@ -111,6 +153,13 @@ const indexHtml = `
 // Middleware
 // -----------------------------------------
 
-const appRenderer = async (req, res) => res.send(indexHtml);
+const appRenderer = async (req, res, next) => {
+  try {
+    const showChatwoot = await shouldShowChatwoot(req.user);
+    res.send(showChatwoot ? indexHtml : indexHtml.replace(chatwootScript, ""));
+  } catch (err) {
+    next(err);
+  }
+};
 
 export default appRenderer;

--- a/src/server/models/thinky.ts
+++ b/src/server/models/thinky.ts
@@ -7,6 +7,7 @@ import dumbThinky from "rethink-knex-adapter";
 
 import { config } from "../../config";
 import knexConfig from "../knex";
+import { instrumentKnex } from "../metrics";
 
 export interface RethinkQuery {
   k: Knex;
@@ -61,6 +62,13 @@ thinkyConn.r.parseCount = async <T>(query: Knex.QueryBuilder | T[]) => {
 
   throw new Error("Multiple columns returned by the query!");
 };
+
+if (config.METRICS_ENABLED) {
+  instrumentKnex(thinkyConn.r.knex, "primary");
+  if (knexConfig.useReader) {
+    instrumentKnex(thinkyConn.r.reader as Knex, "reader");
+  }
+}
 
 if (config.REDIS_URL) {
   thinkyConn.r.redis = redis.createClient({ url: config.REDIS_URL });

--- a/src/server/routes/graphql.ts
+++ b/src/server/routes/graphql.ts
@@ -4,7 +4,10 @@ import { addMocksToSchema } from "@graphql-tools/mock";
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import { ApolloServerPluginLandingPageGraphQLPlayground } from "apollo-server-core";
 import { ApolloError, ApolloServer } from "apollo-server-express";
+import type { ApolloServerPlugin } from "apollo-server-plugin-base";
 import express from "express";
+import type { OperationDefinitionNode } from "graphql";
+import { Kind } from "graphql";
 import { graphqlUploadExpress } from "graphql-upload";
 
 import { schema } from "../../../libs/gql-schema/schema";
@@ -13,6 +16,42 @@ import logger from "../../logger";
 import mocks from "../api/mocks";
 import { resolvers } from "../api/schema";
 import { contextForRequest } from "../contexts";
+import { graphqlErrorsTotal, graphqlRequestDuration } from "../metrics";
+
+const metricsPlugin: ApolloServerPlugin = {
+  requestDidStart: async () => {
+    const startNs = process.hrtime.bigint();
+    let operationType = "unknown";
+
+    return {
+      executionDidStart: async ({ document }) => {
+        const opDef = document.definitions.find(
+          (d): d is OperationDefinitionNode =>
+            d.kind === Kind.OPERATION_DEFINITION
+        );
+        operationType = opDef?.operation ?? "unknown";
+      },
+      willSendResponse: async ({ request }) => {
+        const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
+        graphqlRequestDuration.observe(
+          {
+            operation_name: request.operationName ?? "anonymous",
+            operation_type: operationType
+          },
+          durationSeconds
+        );
+      },
+      didEncounterErrors: async ({ request, errors }) => {
+        for (const error of errors) {
+          graphqlErrorsTotal.inc({
+            operation_name: request.operationName ?? "anonymous",
+            error_type: String(error.extensions?.code ?? "UNKNOWN")
+          });
+        }
+      }
+    };
+  }
+};
 
 export const createRouter = async () => {
   const router = express();
@@ -58,8 +97,8 @@ export const createRouter = async () => {
   const protection = armor.protect();
 
   const plugins = config.isProduction
-    ? []
-    : [ApolloServerPluginLandingPageGraphQLPlayground()];
+    ? [metricsPlugin]
+    : [ApolloServerPluginLandingPageGraphQLPlayground(), metricsPlugin];
 
   const server = new ApolloServer({
     schema: schemaWithMocks,

--- a/src/server/routes/graphql.ts
+++ b/src/server/routes/graphql.ts
@@ -6,8 +6,6 @@ import { ApolloServerPluginLandingPageGraphQLPlayground } from "apollo-server-co
 import { ApolloError, ApolloServer } from "apollo-server-express";
 import type { ApolloServerPlugin } from "apollo-server-plugin-base";
 import express from "express";
-import type { OperationDefinitionNode } from "graphql";
-import { Kind } from "graphql";
 import { graphqlUploadExpress } from "graphql-upload";
 
 import { schema } from "../../../libs/gql-schema/schema";
@@ -21,22 +19,14 @@ import { graphqlErrorsTotal, graphqlRequestDuration } from "../metrics";
 const metricsPlugin: ApolloServerPlugin = {
   requestDidStart: async () => {
     const startNs = process.hrtime.bigint();
-    let operationType = "unknown";
 
     return {
-      executionDidStart: async ({ document }) => {
-        const opDef = document.definitions.find(
-          (d): d is OperationDefinitionNode =>
-            d.kind === Kind.OPERATION_DEFINITION
-        );
-        operationType = opDef?.operation ?? "unknown";
-      },
-      willSendResponse: async ({ request }) => {
+      willSendResponse: async ({ request, operation }) => {
         const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
         graphqlRequestDuration.observe(
           {
             operation_name: request.operationName ?? "anonymous",
-            operation_type: operationType
+            operation_type: operation?.operation ?? "unknown"
           },
           durationSeconds
         );

--- a/src/server/tracing.ts
+++ b/src/server/tracing.ts
@@ -1,0 +1,51 @@
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+// Read directly from process.env — this module must be imported before config.js
+// or any instrumented module (express, pg, http) so the SDK can monkey-patch them.
+const {
+  OTEL_ENABLED,
+  OTEL_EXPORTER_OTLP_ENDPOINT,
+  OTEL_SERVICE_NAME = "spoke",
+  OTEL_SAMPLE_RATE = "0.1",
+  DEPLOY_ENVIRONMENT = "development"
+} = process.env;
+
+if (OTEL_ENABLED === "true") {
+  const sdk = new NodeSDK({
+    serviceName: OTEL_SERVICE_NAME,
+    traceExporter: new OTLPTraceExporter({
+      url: OTEL_EXPORTER_OTLP_ENDPOINT
+    }),
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        // fs instrumentation is extremely noisy and not useful for tracing
+        "@opentelemetry/instrumentation-fs": { enabled: false },
+        // dns is also noisy — every pg connection triggers it
+        "@opentelemetry/instrumentation-dns": { enabled: false },
+        // stamp resource attributes on every span
+        "@opentelemetry/instrumentation-http": {
+          enabled: true
+        }
+      })
+    ]
+  });
+
+  // NodeSDK respects OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG env vars,
+  // but we also accept OTEL_SAMPLE_RATE as a convenience and map it here.
+  process.env.OTEL_TRACES_SAMPLER = "traceidratio";
+  process.env.OTEL_TRACES_SAMPLER_ARG = OTEL_SAMPLE_RATE;
+
+  // OTEL_RESOURCE_ATTRIBUTES lets us attach environment without importing
+  // @opentelemetry/semantic-conventions — the SDK reads this env var natively.
+  if (!process.env.OTEL_RESOURCE_ATTRIBUTES) {
+    process.env.OTEL_RESOURCE_ATTRIBUTES = `deployment.environment=${DEPLOY_ENVIRONMENT}`;
+  }
+
+  sdk.start();
+
+  process.on("SIGTERM", () => {
+    sdk.shutdown().catch(() => {});
+  });
+}

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -78,6 +78,8 @@ const withMetrics = (taskIdentifier: string, task: Task): Task => async (
   helpers
 ) => {
   const startNs = process.hrtime.bigint();
+  const logCtx = { task: taskIdentifier, jobId: helpers.job.id };
+
   try {
     await task(payload, helpers);
     const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
@@ -86,6 +88,11 @@ const withMetrics = (taskIdentifier: string, task: Task): Task => async (
       durationSeconds
     );
     workerTaskTotal.inc({ task_identifier: taskIdentifier, status: "success" });
+    logger.info("Worker task completed", {
+      ...logCtx,
+      elapsedMs: durationSeconds * 1000,
+      attempt: helpers.job.attempts
+    });
   } catch (err) {
     const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
     workerTaskDuration.observe(
@@ -93,6 +100,12 @@ const withMetrics = (taskIdentifier: string, task: Task): Task => async (
       durationSeconds
     );
     workerTaskTotal.inc({ task_identifier: taskIdentifier, status: "error" });
+    logger.warn("Worker task failed", {
+      ...logCtx,
+      elapsedMs: durationSeconds * 1000,
+      attempt: helpers.job.attempts,
+      maxAttempts: helpers.job.max_attempts
+    });
     throw err;
   }
 };

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -1,12 +1,18 @@
 import type { Runner as Scheduler, ScheduleConfig } from "graphile-scheduler";
 import { run as runScheduler } from "graphile-scheduler";
-import type { LogFunctionFactory, Runner, TaskList } from "graphile-worker";
+import type {
+  LogFunctionFactory,
+  Runner,
+  Task,
+  TaskList
+} from "graphile-worker";
 import { Logger, run } from "graphile-worker";
 
 import { config } from "../config";
 import { sleep } from "../lib";
 import logger from "../logger";
 import pgPool from "./db";
+import { workerTaskDuration, workerTaskTotal } from "./metrics";
 import {
   assignTexters,
   TASK_IDENTIFIER as assignTextersIdentifier
@@ -67,6 +73,30 @@ import { wrapProgressTask, wrapProgressTaskList } from "./tasks/utils";
 const logFactory: LogFunctionFactory = (scope) => (level, message, meta) =>
   logger.log({ level, message, ...meta, ...scope });
 
+const withMetrics = (taskIdentifier: string, task: Task): Task => async (
+  payload,
+  helpers
+) => {
+  const startNs = process.hrtime.bigint();
+  try {
+    await task(payload, helpers);
+    const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
+    workerTaskDuration.observe(
+      { task_identifier: taskIdentifier, status: "success" },
+      durationSeconds
+    );
+    workerTaskTotal.inc({ task_identifier: taskIdentifier, status: "success" });
+  } catch (err) {
+    const durationSeconds = Number(process.hrtime.bigint() - startNs) / 1e9;
+    workerTaskDuration.observe(
+      { task_identifier: taskIdentifier, status: "error" },
+      durationSeconds
+    );
+    workerTaskTotal.inc({ task_identifier: taskIdentifier, status: "error" });
+    throw err;
+  }
+};
+
 const graphileLogger = new Logger(logFactory);
 
 let worker: Runner | undefined;
@@ -118,9 +148,13 @@ export const getWorker = async (attempt = 0): Promise<Runner> => {
   if (!workerSemaphore) {
     workerSemaphore = true;
 
+    const instrumentedTaskList: TaskList = Object.fromEntries(
+      Object.entries(taskList).map(([id, task]) => [id, withMetrics(id, task)])
+    );
+
     worker = await run({
       pgPool,
-      taskList,
+      taskList: instrumentedTaskList,
       concurrency: config.WORKER_CONCURRENCY,
       logger: graphileLogger,
       // Signals are handled by Terminus

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -106,12 +106,20 @@ const layouts: LayoutStyles = {
   }
 };
 
+/** Extra bottom inset when Chatwoot launcher is enabled (window vars from app shell). */
+const chatwootFabBottomOffset =
+  typeof window !== "undefined" &&
+  window.CHATWOOT_WEBSITE_TOKEN &&
+  window.CHATWOOT_BASE_URL
+    ? 80
+    : 0;
+
 const components: ComponentStyles = {
   floatingButton: {
     margin: 0,
     top: "auto",
     right: 20,
-    bottom: 20,
+    bottom: 20 + chatwootFabBottomOffset,
     left: "auto",
     position: "fixed"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5421,6 +5421,11 @@
     "@octokit/openapi-types" "^4.0.2"
     "@types/node" ">= 8"
 
+"@opentelemetry/api@^1.4.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
 "@passport-next/passport-strategy@1.x.x":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@passport-next/passport-strategy/-/passport-strategy-1.1.0.tgz#4c0df069e2ec9262791b9ef1e23320c1d73bdb74"
@@ -8865,6 +8870,11 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
 bl@^1.0.0:
   version "1.2.3"
@@ -22654,6 +22664,14 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+prom-client@^15.1.3:
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-15.1.3.tgz#69fa8de93a88bc9783173db5f758dc1c69fa8fc2"
+  integrity sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==
+  dependencies:
+    "@opentelemetry/api" "^1.4.0"
+    tdigest "^0.1.1"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -26282,6 +26300,13 @@ tarn@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tarn/-/tarn-3.0.2.tgz#73b6140fbb881b71559c4f8bfde3d9a4b3d27693"
   integrity sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 teeny-request@^7.0.0:
   version "7.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4676,6 +4676,24 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
+"@grpc/grpc-js@^1.14.3":
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#e73ff57d97802f063999545f43ebb2b1eca65d9d"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
+  dependencies:
+    "@grpc/proto-loader" "^0.8.0"
+    "@js-sdsl/ordered-map" "^4.4.2"
+
+"@grpc/proto-loader@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.1.tgz#5a6b290ccbfb1ae2f6775afb74e9898bd8c5d4e8"
+  integrity sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.5.5"
+    yargs "^17.7.2"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -5150,6 +5168,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
+
 "@material-ui/core@^4.12.4":
   version "4.12.4"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.4.tgz#4ac17488e8fcaf55eb6a7f5efb2a131e10138a73"
@@ -5421,10 +5444,749 @@
     "@octokit/openapi-types" "^4.0.2"
     "@types/node" ">= 8"
 
-"@opentelemetry/api@^1.4.0":
+"@opentelemetry/api-logs@0.218.0", "@opentelemetry/api-logs@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz#7b9818e8dfdf1d3dcab88bfe4d6724f2f831f7ec"
+  integrity sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==
+  dependencies:
+    "@opentelemetry/api" "^1.3.0"
+
+"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.4.0", "@opentelemetry/api@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
   integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
+"@opentelemetry/auto-instrumentations-node@^0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.76.0.tgz#eb8f646dee1d7e9d4455a6af247045c388751018"
+  integrity sha512-44KWgqsMuqfV4UhOcwwnDeK8CpB5LT1MmpZj6sKXFXu2q6rjKo622pWgOgn5Ntp5Qal9q1uBX2VS8mvTpsMeyw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/instrumentation-amqplib" "^0.65.0"
+    "@opentelemetry/instrumentation-aws-lambda" "^0.70.0"
+    "@opentelemetry/instrumentation-aws-sdk" "^0.73.0"
+    "@opentelemetry/instrumentation-bunyan" "^0.63.0"
+    "@opentelemetry/instrumentation-cassandra-driver" "^0.63.0"
+    "@opentelemetry/instrumentation-connect" "^0.61.0"
+    "@opentelemetry/instrumentation-cucumber" "^0.34.0"
+    "@opentelemetry/instrumentation-dataloader" "^0.35.0"
+    "@opentelemetry/instrumentation-dns" "^0.61.0"
+    "@opentelemetry/instrumentation-express" "^0.66.0"
+    "@opentelemetry/instrumentation-fs" "^0.37.0"
+    "@opentelemetry/instrumentation-generic-pool" "^0.61.0"
+    "@opentelemetry/instrumentation-graphql" "^0.66.0"
+    "@opentelemetry/instrumentation-grpc" "^0.218.0"
+    "@opentelemetry/instrumentation-hapi" "^0.64.0"
+    "@opentelemetry/instrumentation-http" "^0.218.0"
+    "@opentelemetry/instrumentation-ioredis" "^0.66.0"
+    "@opentelemetry/instrumentation-kafkajs" "^0.27.0"
+    "@opentelemetry/instrumentation-knex" "^0.62.0"
+    "@opentelemetry/instrumentation-koa" "^0.66.0"
+    "@opentelemetry/instrumentation-lru-memoizer" "^0.62.0"
+    "@opentelemetry/instrumentation-memcached" "^0.61.0"
+    "@opentelemetry/instrumentation-mongodb" "^0.71.0"
+    "@opentelemetry/instrumentation-mongoose" "^0.64.0"
+    "@opentelemetry/instrumentation-mysql" "^0.64.0"
+    "@opentelemetry/instrumentation-mysql2" "^0.64.0"
+    "@opentelemetry/instrumentation-nestjs-core" "^0.64.0"
+    "@opentelemetry/instrumentation-net" "^0.62.0"
+    "@opentelemetry/instrumentation-openai" "^0.16.0"
+    "@opentelemetry/instrumentation-oracledb" "^0.43.0"
+    "@opentelemetry/instrumentation-pg" "^0.70.0"
+    "@opentelemetry/instrumentation-pino" "^0.64.0"
+    "@opentelemetry/instrumentation-redis" "^0.66.0"
+    "@opentelemetry/instrumentation-restify" "^0.63.0"
+    "@opentelemetry/instrumentation-router" "^0.62.0"
+    "@opentelemetry/instrumentation-runtime-node" "^0.31.0"
+    "@opentelemetry/instrumentation-socket.io" "^0.65.0"
+    "@opentelemetry/instrumentation-tedious" "^0.37.0"
+    "@opentelemetry/instrumentation-undici" "^0.28.0"
+    "@opentelemetry/instrumentation-winston" "^0.62.0"
+    "@opentelemetry/resource-detector-alibaba-cloud" "^0.33.8"
+    "@opentelemetry/resource-detector-aws" "^2.18.0"
+    "@opentelemetry/resource-detector-azure" "^0.26.0"
+    "@opentelemetry/resource-detector-container" "^0.8.9"
+    "@opentelemetry/resource-detector-gcp" "^0.53.0"
+    "@opentelemetry/resources" "^2.0.0"
+    "@opentelemetry/sdk-node" "^0.218.0"
+
+"@opentelemetry/configuration@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/configuration/-/configuration-0.218.0.tgz#a5fdd50ec9cfa0adb3bb41202cb39f79c5f4e7d9"
+  integrity sha512-W8wIz7H2R1pufR5jfjb3gU2XkMpm2x/7b1RJcsuzvd70Il/rWWE+g5/Od7hQKrxRTSrTrOWlru101PWXz5I1EQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    yaml "^2.0.0"
+
+"@opentelemetry/context-async-hooks@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz#1555a6fb269596416d8c626fd020c3f2c38e071f"
+  integrity sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==
+
+"@opentelemetry/core@2.7.1", "@opentelemetry/core@^2.0.0":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.7.1.tgz#162bfab46d6ff4da1bef240ea52e23a926b0fdbc"
+  integrity sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/exporter-logs-otlp-grpc@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.218.0.tgz#7e5a7e624074d6449590c851d58efe60096314b3"
+  integrity sha512-hoxrNH1l/Xy6F9WTJ5IK+6j1r9nQFlPOmrnTlhYHTySdunfXLmUCPv3bQtKYntxag9h3wLYBZQ2HI6FOx+BT2g==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/sdk-logs" "0.218.0"
+
+"@opentelemetry/exporter-logs-otlp-http@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz#0996cb45e0ebc6c7465445430a018edcac9871b4"
+  integrity sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/sdk-logs" "0.218.0"
+
+"@opentelemetry/exporter-logs-otlp-proto@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.218.0.tgz#e539720b2e145e85a7a4901a1eabb0b2e77990f8"
+  integrity sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-logs" "0.218.0"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-metrics-otlp-grpc@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.218.0.tgz#6d66c2638702489d063b8857741eee9cea1d21d6"
+  integrity sha512-YapQ9vNMX0NSZF6LK5pWAFfjpJleV2O9uYWfYGeb/5F1Kb9rPGK8tZDMJFa/sOksgdFuflDvYuA0B4qjDB4fjQ==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.218.0"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+
+"@opentelemetry/exporter-metrics-otlp-http@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.218.0.tgz#c205581585d04c5106d1ca766e23632006e46a2c"
+  integrity sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+
+"@opentelemetry/exporter-metrics-otlp-proto@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.218.0.tgz#66642b8bb5e654ca7a5944a4f0b490814fc875fd"
+  integrity sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.218.0"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+
+"@opentelemetry/exporter-prometheus@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.218.0.tgz#41bddc97d34cd9d9993382b9c10fed19a8de63f4"
+  integrity sha512-RT5oEyu1kddZJ1vt7/BUo5wV+P7hpNAESsR3dUd3+8deHuX7gWNoCOZn+SfDT+hJHlIJ5h/AxiCLXIrutswDJg==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/exporter-trace-otlp-grpc@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.218.0.tgz#5d5532ab94d5514bec8aedc19ce3170b6381eed1"
+  integrity sha512-3fXxVQEj9TNAFaCi79JeFKfeLd0sDtInaR3gaZDVlzNSPHtz8PZuCV34JKWjD4XXzT20IdMe8IpX6mRVNDA4Tw==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-trace-otlp-http@0.218.0", "@opentelemetry/exporter-trace-otlp-http@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz#36d6abf6d639b9ea861603c61f434751c0b1a0ea"
+  integrity sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-trace-otlp-proto@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.218.0.tgz#de0b2b3545149dafedd2b948fb891f9bf962940c"
+  integrity sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/exporter-zipkin@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.7.1.tgz#3b79d223adc8c097ba3323e4de4ed8abb83c789e"
+  integrity sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/instrumentation-amqplib@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.65.0.tgz#9a8371103f9000db23074d7e3f1430c40d247a4e"
+  integrity sha512-fF7fNHA59n3y23ROfst2EbSxmP+L3E+snZO6aMU4w4xD84mfejAivspIAsqa9arX5HZlBK6dslHz5dWGNp5D0A==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-aws-lambda@^0.70.0":
+  version "0.70.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.70.0.tgz#4ae315a24c054c647be347d5d3fdf87ca225a2e9"
+  integrity sha512-HT74cQxi/iiVEz5dRdNdfGCFzPFbkxSiwHfFPHDwkRcr1JKQqI6hm8qeXEvEiJ+36xIU1KkQMDfeThJ1ifnUiA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+    "@types/aws-lambda" "^8.10.155"
+
+"@opentelemetry/instrumentation-aws-sdk@^0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.73.0.tgz#2cedd670f36ce678d6e009cd6591b17aec1d130b"
+  integrity sha512-0INPkHbR6o4J3psE+ncwWaE7qtDpb2p+i+qfV82cfwYLCXavYCGosBZ/S4pOErDVJYIyQVIsNAHhaUgaL313SQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.34.0"
+
+"@opentelemetry/instrumentation-bunyan@^0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.63.0.tgz#024ef8ac7f1bbbe99cd44d979e9d132e4b87df78"
+  integrity sha512-z0xPSZ62d3I7sG2sUTyQ5/ES1RdESP2eOETiMLY9gPSp+HZwbsAyj7T/2sdZKYD+O2ajRHZEil+DBoUolf1ocQ==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.218.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@types/bunyan" "1.8.11"
+
+"@opentelemetry/instrumentation-cassandra-driver@^0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.63.0.tgz#1260e9cddb9b31a109341fe861518e62663a414b"
+  integrity sha512-jnVTOr3h/46UDalEwJ4ITux8UWwHmnsOik5WFs3JB/UrUj8Wad5eI+KpOEBuOUeOfPB9sce11qgVw3WXU2r+hg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.37.0"
+
+"@opentelemetry/instrumentation-connect@^0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.61.0.tgz#b7f11da3a9bd80fc224747e44cf579a1aad94d93"
+  integrity sha512-ZTQ0W3Lb7GJsOd+72cG8FJQKA5DqYfELJGLmChrJIezRSLfJIfofwKEGLX5rMtFJmwckpichQkBZWjid5dvnVQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+    "@types/connect" "3.4.38"
+
+"@opentelemetry/instrumentation-cucumber@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-cucumber/-/instrumentation-cucumber-0.34.0.tgz#e561a530749e7e75fc505313d47c288ef3ef4aaf"
+  integrity sha512-VK63Cm8osAdsSZpULPk+qnNktQUJzmnIOv2wuh79fV41WuTM38uOFC3s978/24pDkSljhN4EYCbPRLrAhXfKSA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-dataloader@^0.35.0":
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.35.0.tgz#d0f0011bdfad461e5bd63eeb89edfe0c58fb93c8"
+  integrity sha512-6x6UPP0tLzrdj15PIEN3qgp/WCcESCavHJfkIKoyLmy4UjGLF1KgEUMyD74xhbKGo426uvMbhvCgZC0ye8nO/A==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation-dns@^0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.61.0.tgz#57bad2f2b81f6a84563facd9f3312bac94b50166"
+  integrity sha512-5D8xFaw9GXq9ZIOAvG7NPDivFfZWFAekLGFn1B7ppyhuAYBVHGybFpx4Q9BV1Uup3yzCdiD78KhyH7c3dKOYSw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation-express@^0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-express/-/instrumentation-express-0.66.0.tgz#41f12f657112a2049a7a007db2ebdb15338b01da"
+  integrity sha512-G1xTh5M5shklMgIyUXWDjU2BakulKtcISaM4U5TyanvO7R4xbB3iC7YQ8QKegLXaOs81Ku8RlcIcbYRrz/82wQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-fs@^0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.37.0.tgz#c7982a330a4c98dea8b1abc372c980a2fd2ccca8"
+  integrity sha512-5mxhFuwAK0FFvisUdvuywaZ9ySMZ15HfbN6IpLn0gwRh9s1/QBcpLznQ/A15cZs1QFtBJ+JXIHdwY7WOD0c4Eg==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation-generic-pool@^0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.61.0.tgz#b3db39fd0ce9de967a144dbcd001b617a9389cce"
+  integrity sha512-tvp5PWnGRPHY/kz9Kg1IRLBL0qUAxMSNG623f+ZGEsvnCVEjr3tFyw1JGQzM+B3eZKkO+Dp/LYrtOSfb69D5lA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation-graphql@^0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.66.0.tgz#aac53ee679edb654dbbd12e92eb8bc2ebf221312"
+  integrity sha512-D4PN1tStj6rnOdofnt2xINJjtT1k2ockzaODrn76VEBZeqJ3QsEvKFfunB0EFAohO4xswVp14VAVmKNnGzA1Dw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation-grpc@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.218.0.tgz#c88edb20986afc376e2f2f2c721ce0d05fd3a273"
+  integrity sha512-kcDCNrC7IWNXEKQriGrwuh5jjbMFU5exOQzU9ufEY9UkACNcgYIdOd7XpX3IqZ3UPSnZyZtlwgfsbC5SNlEDbA==
+  dependencies:
+    "@opentelemetry/instrumentation" "0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/instrumentation-hapi@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.64.0.tgz#0ca91787ca3046c31149145cc516e975d8ac1dab"
+  integrity sha512-PCHgCICCDz7p9BgCU9gQz2smbqu4V4P8QtWJ7DLjL3bmzSdrgy6EGvecDg1YuhjBsoN08SR+y36hgdHkqCgrzQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-http@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-http/-/instrumentation-http-0.218.0.tgz#0b26b702a6288fa11bdea48ff4a3635385a7d587"
+  integrity sha512-x9djaqdzpT8WAboep1H9nCAQ1E+MMsm08TNfA02TqM3bNNddZeiim+E3KMWVQFaX6JpUy7V0nm/wfN/K2Em+Zw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/instrumentation" "0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+    forwarded-parse "2.1.2"
+
+"@opentelemetry/instrumentation-ioredis@^0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.66.0.tgz#f0306a5a0ff80eeb71312e2dac19d1beccc918ec"
+  integrity sha512-UfTAcaBKCzLUZ9opvfOLV4bH46XiNFqUsKykfPCIefDIxJ1iUYtMOucNaiZ+/kjQdPy5i6Ef5tk2IAjxol4X1w==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/redis-common" "^0.38.3"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-kafkajs@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.27.0.tgz#5e608c020d17a1922aa0674414ed2718e184c483"
+  integrity sha512-kl/C2AU4KZGHlMZD12nMFXcMjxSHvu5Q0UPSQ6IJeBfCadYuWgW+sWIa2JZVK/A0qRYm2cncekJyeBHQDyfUUg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.30.0"
+
+"@opentelemetry/instrumentation-knex@^0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.62.0.tgz#76cffe686758312b33739dd060ddc302bb74a253"
+  integrity sha512-XgfhCAWwSqA0YnwaEKdpvQMavc90D3R65frhLCO9JNl867EulNps9tm6pjGIg+GiYuewn00gEzW4HQ5btgYxGQ==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.33.1"
+
+"@opentelemetry/instrumentation-koa@^0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.66.0.tgz#6ba5e2f97400bcdaa4085bbae85fe953780d2b0a"
+  integrity sha512-04x/z21WTMEfy3lUSr4aTj8WsTN3OZF901hJ+ciOwdwf7AK8UJTpZCXw6KQ3G4Vag56q1HoMihCONeWZLeld1g==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.36.0"
+
+"@opentelemetry/instrumentation-lru-memoizer@^0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.62.0.tgz#7ba34ae12c4933020f871ed6e4309e0f76311c62"
+  integrity sha512-AlGKIdk6ZT7WmIozfUb2LjOcI3AhQrvAXKX0zi1cVcnw2QlRbVYyV5GTa2Th9ebuczVfWPaoPrmZw61zCp/czw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation-memcached@^0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.61.0.tgz#fa493d048994372197a6262ec12a1fe719802a22"
+  integrity sha512-qiCR9Wovf5AHzn6g+LXhvwMmv2I6zhHz2I2tEHZMmBuD8c18bkJzGFxHoSBlxdApRT+SW13r9472dDMm4BRjgQ==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/memcached" "^2.2.6"
+
+"@opentelemetry/instrumentation-mongodb@^0.71.0":
+  version "0.71.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.71.0.tgz#d011393ccb0d049fc13a13caa82e3ffc79e1652e"
+  integrity sha512-6rwfVjAUY69CKkyGqzL+F5X7Nzw0+Ke9pOxk9xUPJpy8vracZxuQYF7rWu02sV1xOgi4u52449SuVhD+zaSiIA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-mongoose@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.64.0.tgz#34b43a7e6f32ae0713436b1697514de49b783dd8"
+  integrity sha512-iCIqeUaERN8Uc5Rrtg4zvQ6d7z5JQ5iUmbnr/JHYPxAidDowmRc8/wDMJeMKRfLPTj336Zu0ec7rH/ak/4N9vw==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-mysql2@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.64.0.tgz#5c07bf4feedc6c071601b55e5d077d423eb26289"
+  integrity sha512-yTu0mYh/qJPSE86VmNLQww5uugDyvCS2KJIPfPtIk2ufoEUoHPsV6Iynnvmz588Moq04aBLxfTa/EtE4A2ykWA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@opentelemetry/sql-common" "^0.41.2"
+
+"@opentelemetry/instrumentation-mysql@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.64.0.tgz#e6b58945b6182c597bfc4111f0760789097eef4d"
+  integrity sha512-W1w76AJkP7i0uzzAe7nsCMWq4+EMSA550f1lAmxDPdQC5FnreNbRIm/tod2OS9gVrYvRrQXNkFmZJKGo4kzCnw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/mysql" "2.15.27"
+
+"@opentelemetry/instrumentation-nestjs-core@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.64.0.tgz#a57387dbaaa2f122caf39a43fc4e57b71595a400"
+  integrity sha512-PW1ArxryMwF8/IXq1nzlQs7tmr/fWd1tf71AHevZT3Fm0hW7jRX9JEfYgIAcKDvmbqcJEr5K1224NEimrRPbuQ==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.30.0"
+
+"@opentelemetry/instrumentation-net@^0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-net/-/instrumentation-net-0.62.0.tgz#83339f61663441c45b6327a3c6a264f24f2db44f"
+  integrity sha512-Gt2kzpACpmIad+q3LQqe8UNHuoVvdLuFpB6SN/A6xLPKNllb+ksPUYQhj1kXdZOpcFZNGKDXHyN+TUCVCk1TRw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-openai@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-openai/-/instrumentation-openai-0.16.0.tgz#883d4ea4c292e1ef87795aaf1b57d52ff8c29b83"
+  integrity sha512-I0KKybyqqFOxSBgYKQNdR/EF3LvzSaAUT7Y75xkjbgscY+V8UWDpUbY68POLhUC3SKMlGvZmrTSxcQ+Y0vRhNw==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.218.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.36.0"
+
+"@opentelemetry/instrumentation-oracledb@^0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-oracledb/-/instrumentation-oracledb-0.43.0.tgz#351aee73feca8c7d9856caef2d7a16d2495f5a97"
+  integrity sha512-7Z4kOOdnrHX4S5gCeWhnnpWQwEd7weRjDhJA1nSrwTYtAcVWNjk5wsMKHBCTDCN0uJtA9T6PouZ+AKRYiS1Rrg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.34.0"
+    "@types/oracledb" "6.5.2"
+
+"@opentelemetry/instrumentation-pg@^0.70.0":
+  version "0.70.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.70.0.tgz#f5e16a78e4432c52a07971ce1acf1aac2a19eab4"
+  integrity sha512-g8WXwwOUXfjiEmATwjB/33QKE2AkIpNe4KIuJJh4djtXgCL0Wne+AzAfjuDIAspGvO1txQp8ibKsLd3SBmcvJA==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.34.0"
+    "@opentelemetry/sql-common" "^0.41.2"
+    "@types/pg" "8.15.6"
+    "@types/pg-pool" "2.0.7"
+
+"@opentelemetry/instrumentation-pino@^0.64.0":
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.64.0.tgz#3107deb4ac29474ca4e0c4a044bba1be1740bf86"
+  integrity sha512-+vDL7tZMZjkp8BpYMx/cL2/HWGsNUqKcRmAIIEaQu/6F44oM6xGDMCSqMKHdKCsH1+WW52EYdHbWkVGTF0KVsQ==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.218.0"
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation-redis@^0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.66.0.tgz#60486cf4513cd0a141e36203ce5fc228dd2b188a"
+  integrity sha512-bVShkag6vP2VQO0cpA8CHjOohWbKNYLyjiwGkOnSAwou1TPc6pf9DssFUxwqN2XF1J4oqP0LVSvN9kZUzMecfA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/redis-common" "^0.38.3"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-restify@^0.63.0":
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.63.0.tgz#4d7cc2b451ce366645c2cd83427b26b9e95bb865"
+  integrity sha512-Z73YxZpt0Y56uRu2pRWOjO5wXHvZqF46K4czoKRTGlUifzzFmUZxyOeAAECACuMRSLZmZ394WJin0MDgU9iW9w==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-router@^0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-router/-/instrumentation-router-0.62.0.tgz#573a2107292d0cbbf342a25bf302b31b6c85c50e"
+  integrity sha512-0w8ok7GbXtYvX7TtLp72qQJKNyI7lD72Fy2NsNKIcQAv6TqGox5javFyXrIrCAtZHCONePxeAwAYj1Qd9si9OQ==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-runtime-node@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-runtime-node/-/instrumentation-runtime-node-0.31.0.tgz#0a4e60f37d51a07dc4acc1f27dd9f416bf72f62e"
+  integrity sha512-HkLsuEfUDahFiL/xFtEqJDMp7sp8ynOtA045bJi9nAH8CrPvljPW5SgJQb2mQqEYJQopbWYZ2lPqQEfj7bYgJg==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.218.0"
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation-socket.io@^0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-socket.io/-/instrumentation-socket.io-0.65.0.tgz#34070e605ee48549a471d146b42f24ae6b25d5b0"
+  integrity sha512-dNvIbD40h0z69stQ9cIeAWRyy5WyQM1a1XnFthekc/oi/ipX4E6oYJBM4X2xKBxjZMTjdV5VshLoNeYMSBsnjw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation-tedious@^0.37.0":
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.37.0.tgz#5e3eeb3365dc58810a2b4b899c40622e054291ba"
+  integrity sha512-cGLF46UsgeI1334atJxLO36yQlV7WXKg35Mp+e2NXo2vOTfIZTVqoKOzExVOTOwT4AQjfGVEDxyq5wXybUYXIA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/tedious" "^4.0.14"
+
+"@opentelemetry/instrumentation-undici@^0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.28.0.tgz#cc8f9b67d3db9899cf927fdbb57fb3395a69905f"
+  integrity sha512-7nh4Gw7PhYtQm82FIJtWUhx6iZQJj0bdkKe2RQb3XNIyxu0o9rM1J5Xt083SsG2tCbQZpX9/mlDxhTrK1Z/lVQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+    "@opentelemetry/semantic-conventions" "^1.24.0"
+
+"@opentelemetry/instrumentation-winston@^0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.62.0.tgz#41c12b5596e9709a09f4694b6338eb4024c1deff"
+  integrity sha512-pr1U9ZV4RRy23qMVrRzebfxwDWjp44xA7sC0PAdeW9v4HDcfOr0ejdTJmIsBGvhkNHPBajfieaIF9b6/9wjErA==
+  dependencies:
+    "@opentelemetry/api-logs" "^0.218.0"
+    "@opentelemetry/instrumentation" "^0.218.0"
+
+"@opentelemetry/instrumentation@0.218.0", "@opentelemetry/instrumentation@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz#fcceb4ffb45f99c0d292600769150fc5944dc3e9"
+  integrity sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
+"@opentelemetry/otlp-exporter-base@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz#f33e3217ce568756baa132fabe30f0c9345db086"
+  integrity sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+
+"@opentelemetry/otlp-grpc-exporter-base@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.218.0.tgz#dc5a1fec716245d84dc4167de9b1c607e07fb6a7"
+  integrity sha512-H/lCGJ536N98VpYJOaWTQOkv4Dx6TnmStK6Rqfu1W7KkFbPAx04hjdYEMZF/YbnHzPUSIK4kM6OE2GKGBTpV9A==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.3"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/otlp-transformer" "0.218.0"
+
+"@opentelemetry/otlp-transformer@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz#6784d0ddd13803c63a1b24072606c02fc21b9071"
+  integrity sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-logs" "0.218.0"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/propagator-b3@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-b3/-/propagator-b3-2.7.1.tgz#107fe3e16d0728c489edbad221c402ee197514a4"
+  integrity sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+
+"@opentelemetry/propagator-jaeger@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz#e8ebf3f6c0e9aa525cf041893425889cf3e69125"
+  integrity sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+
+"@opentelemetry/redis-common@^0.38.3":
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz#31a0464a48a991c29408614e3725d94db7c11aee"
+  integrity sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==
+
+"@opentelemetry/resource-detector-alibaba-cloud@^0.33.8":
+  version "0.33.8"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.33.8.tgz#b639a1d80e5807fc0ad71eef29969791b178db78"
+  integrity sha512-RnSB/uxkElny0/WBFEtIG2HRG0cpSNTRdE+YSB7Poa+uljK+ddCacEZYz/PMgZh+cs586XstJQxdyjz0jtcAug==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+
+"@opentelemetry/resource-detector-aws@^2.18.0":
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-aws/-/resource-detector-aws-2.18.0.tgz#fe94369b877df282491cf65e82ce406f494ed2a7"
+  integrity sha512-wyMM4UoRuHvI2KjqnTzvyW8Yv7MKRGA+I78Xti6gTEw7hBhqXU1SRo+f9KrsQfeeiOn+TkDuvxavuaAQbD3i6g==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/resource-detector-azure@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.26.0.tgz#6fded3a6f4c748b899f30a3705366f8df419df09"
+  integrity sha512-7KxF7mlwI2nKja/iEdwPqOaS0QAJbhT9ye4DeYZnXdOS/4phfonk5nSmyGDBYhBL7J30MPL91oZNuGYRKXZAXA==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+    "@opentelemetry/semantic-conventions" "^1.37.0"
+
+"@opentelemetry/resource-detector-container@^0.8.9":
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-container/-/resource-detector-container-0.8.9.tgz#04a847050c6fd0c05d2022c6cf0d3c3f734970a1"
+  integrity sha512-Xd2C4HjW9hl75iqZT7tQNy2yRBUqNucq2O9+e0FJRNkbiItInYVMzc0S0KDXcx/vZBwNmlrKS3R0uLCU9ULsGA==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+
+"@opentelemetry/resource-detector-gcp@^0.53.0":
+  version "0.53.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.53.0.tgz#6469f977228c222b400a6092a5cd516f2d2972dd"
+  integrity sha512-RCV31v23ZwZfYR3LPkuORHTHIOvfm3hZBT7hAzSO0+oAIrG/Dm0ld5tV4lYNO05GjI7sHQdRcbSqzEYAvQcQuw==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/resources" "^2.0.0"
+    gcp-metadata "^8.0.0"
+
+"@opentelemetry/resources@2.7.1", "@opentelemetry/resources@^2.0.0":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.7.1.tgz#3b2a9179f6119bb1f2cddefe41ba9b2855504a5d"
+  integrity sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-logs@0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz#78886fe300b82802cee9963208b2af326b928af5"
+  integrity sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-metrics@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz#b713f69dd67933ecc9c61357f1d452cdc9f4e281"
+  integrity sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+
+"@opentelemetry/sdk-node@^0.218.0":
+  version "0.218.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-node/-/sdk-node-0.218.0.tgz#cf8bdc0c993387189c7c474612e0f801505feb97"
+  integrity sha512-tPMjHrLV5gsfNdYqoRHjeGbCAZBXXD9c1Qo/2ut7VwnUABDNh76xNxrT0SEhkIIJuCN45bbN1vZnYL1gY0IkOg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.218.0"
+    "@opentelemetry/configuration" "0.218.0"
+    "@opentelemetry/context-async-hooks" "2.7.1"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/exporter-logs-otlp-grpc" "0.218.0"
+    "@opentelemetry/exporter-logs-otlp-http" "0.218.0"
+    "@opentelemetry/exporter-logs-otlp-proto" "0.218.0"
+    "@opentelemetry/exporter-metrics-otlp-grpc" "0.218.0"
+    "@opentelemetry/exporter-metrics-otlp-http" "0.218.0"
+    "@opentelemetry/exporter-metrics-otlp-proto" "0.218.0"
+    "@opentelemetry/exporter-prometheus" "0.218.0"
+    "@opentelemetry/exporter-trace-otlp-grpc" "0.218.0"
+    "@opentelemetry/exporter-trace-otlp-http" "0.218.0"
+    "@opentelemetry/exporter-trace-otlp-proto" "0.218.0"
+    "@opentelemetry/exporter-zipkin" "2.7.1"
+    "@opentelemetry/instrumentation" "0.218.0"
+    "@opentelemetry/otlp-exporter-base" "0.218.0"
+    "@opentelemetry/propagator-b3" "2.7.1"
+    "@opentelemetry/propagator-jaeger" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/sdk-logs" "0.218.0"
+    "@opentelemetry/sdk-metrics" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+    "@opentelemetry/sdk-trace-node" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-base@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz#9160c3af9ef2219c26563abd136e22fb7d19b34f"
+  integrity sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==
+  dependencies:
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/resources" "2.7.1"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-node@2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz#54dedb8e77fa51a6d02fc2192097739266c82168"
+  integrity sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==
+  dependencies:
+    "@opentelemetry/context-async-hooks" "2.7.1"
+    "@opentelemetry/core" "2.7.1"
+    "@opentelemetry/sdk-trace-base" "2.7.1"
+
+"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.37.0":
+  version "1.41.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz#b04e7151c5913a7a006d4f465479da75efb98a7a"
+  integrity sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==
+
+"@opentelemetry/sql-common@^0.41.2":
+  version "0.41.2"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz#7f4a14166cfd6c9ffe89096db1cc75eaf6443b19"
+  integrity sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
 
 "@passport-next/passport-strategy@1.x.x":
   version "1.1.0"
@@ -5480,10 +6242,20 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
   integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
 
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
+
 "@protobufjs/eventemitter@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
   integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
 "@protobufjs/fetch@^1.1.0":
   version "1.1.0"
@@ -5492,6 +6264,13 @@
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
     "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
@@ -5502,6 +6281,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
   integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/inquire@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.2.tgz#ae64fbc014ff44c8bfad03dd4c93cd2d6a4c82db"
+  integrity sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==
 
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
@@ -5517,6 +6301,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
+  integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
 "@redis/bloom@1.0.2":
   version "1.0.2"
@@ -5902,6 +6691,11 @@
   dependencies:
     aphrodite "*"
 
+"@types/aws-lambda@^8.10.155":
+  version "8.10.161"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.161.tgz#36d95723ec46d3d555bf0684f83cf4d4369a28ad"
+  integrity sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
@@ -5969,6 +6763,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bunyan@1.8.11":
+  version "1.8.11"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.11.tgz#0b9e7578a5aa2390faf12a460827154902299638"
+  integrity sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
@@ -6012,6 +6813,13 @@
   version "3.4.33"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
   integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
+
+"@types/connect@3.4.38":
+  version "3.4.38"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
   dependencies:
     "@types/node" "*"
 
@@ -6388,6 +7196,13 @@
   resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
   integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
+"@types/memcached@^2.2.6":
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/@types/memcached/-/memcached-2.2.10.tgz#113f9e3a451d6b5e0a3822e06d9feb52e63e954a"
+  integrity sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mime@*":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
@@ -6402,6 +7217,13 @@
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
+
+"@types/mysql@2.15.27":
+  version "2.15.27"
+  resolved "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.27.tgz#fb13b0e8614d39d42f40f381217ec3215915f1e9"
+  integrity sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/node-cron@^2.0.3":
   version "2.0.3"
@@ -6424,6 +7246,13 @@
   version "14.14.31"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.31.tgz#72286bd33d137aa0d152d47ec7c1762563d34055"
   integrity sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==
+
+"@types/node@>=13.7.0":
+  version "25.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.1.tgz#3bda556db500ae4319c08e7fc9ab94f19013ba0b"
+  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
 
 "@types/node@^10.1.0":
   version "10.17.14"
@@ -6452,6 +7281,13 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/oracledb@6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@types/oracledb/-/oracledb-6.5.2.tgz#194cd0f13436f9e1e744a6e5e056a7ca400536d5"
+  integrity sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/papaparse@^5.3.5":
   version "5.3.5"
   resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-5.3.5.tgz#e5ad94b1fe98e2a8ea0b03284b83d2cb252bbf39"
@@ -6471,6 +7307,13 @@
   dependencies:
     "@types/express" "*"
 
+"@types/pg-pool@2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/pg-pool/-/pg-pool-2.0.7.tgz#c17945a74472d9a3beaf8e66d5aa6fc938328734"
+  integrity sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==
+  dependencies:
+    "@types/pg" "*"
+
 "@types/pg-types@*":
   version "1.11.5"
   resolved "https://registry.yarnpkg.com/@types/pg-types/-/pg-types-1.11.5.tgz#1eebbe62b6772fcc75c18957a90f933d155e005b"
@@ -6480,6 +7323,15 @@
   version "8.6.5"
   resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.5.tgz#2dce9cb468a6a5e0f1296a59aea3ac75dd27b702"
   integrity sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
+"@types/pg@8.15.6":
+  version "8.15.6"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.6.tgz#4df7590b9ac557cbe5479e0074ec1540cbddad9b"
+  integrity sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==
   dependencies:
     "@types/node" "*"
     pg-protocol "*"
@@ -6739,6 +7591,13 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+
+"@types/tedious@^4.0.14":
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/@types/tedious/-/tedious-4.0.14.tgz#868118e7a67808258c05158e9cad89ca58a2aec1"
+  integrity sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/trusted-types@^2.0.2":
   version "2.0.2"
@@ -7487,6 +8346,11 @@ acorn-import-assertions@^1.7.6:
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
   integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
+acorn-import-attributes@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
+
 acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -7516,6 +8380,11 @@ acorn@^7.1.1:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
+
+acorn@^8.15.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
 acorn@^8.2.4:
   version "8.7.0"
@@ -7556,6 +8425,11 @@ agent-base@6:
   integrity sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==
   dependencies:
     debug "4"
+
+agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 aggregate-error@^3.0.0:
   version "3.0.1"
@@ -9839,6 +10713,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+cjs-module-lexer@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
+  integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -9962,6 +10841,15 @@ cliui@^7.0.2:
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
@@ -11292,6 +12180,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -11372,6 +12265,13 @@ debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
+
+debug@^4.3.5:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 decamelize-keys@^1.0.0:
   version "1.1.0"
@@ -13613,6 +14513,14 @@ fecha@^2.3.3:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-2.3.3.tgz#948e74157df1a32fd1b12c3a3c3cdcb6ec9d96cd"
   integrity sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -13990,6 +14898,13 @@ formdata-node@^4.3.1:
     node-domexception "1.0.0"
     web-streams-polyfill "4.0.0-beta.1"
 
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
+
 formidable@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
@@ -14009,6 +14924,11 @@ formidable@^2.0.1:
     hexoid "1.0.0"
     once "1.4.0"
     qs "6.9.3"
+
+forwarded-parse@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz#08511eddaaa2ddfd56ba11138eee7df117a09325"
+  integrity sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -14222,6 +15142,15 @@ gaxios@^4.0.0:
     is-stream "^2.0.0"
     node-fetch "^2.3.0"
 
+gaxios@^7.0.0:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.4.tgz#33a5b78e2c5c01cf5a5d17f58dd188839867fc9c"
+  integrity sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+
 gaze@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.3.tgz#c441733e13b927ac8c0ff0b4c3b033f28812924a"
@@ -14235,6 +15164,15 @@ gcp-metadata@^4.2.0:
   integrity sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==
   dependencies:
     gaxios "^4.0.0"
+    json-bigint "^1.0.0"
+
+gcp-metadata@^8.0.0:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz#e62e3373ddf41fc727ccc31c55c687b798bee898"
+  integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
+  dependencies:
+    gaxios "^7.0.0"
+    google-logging-utils "^1.0.0"
     json-bigint "^1.0.0"
 
 gcs-resumable-upload@^3.1.0:
@@ -14679,6 +15617,11 @@ google-libphonenumber@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.6.tgz#3d725b48ff44706b80246e77f95f2c2fdc6fd729"
   integrity sha512-6QCQAaKJlSd/1dUqvdQf7zzfb3uiZHsG8yhCfOdCVRfMuPZ/VDIEB47y5SYwjPQJPs7ebfW5jj6PeobB9JJ4JA==
+
+google-logging-utils@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
 
 google-p12-pem@^3.0.3:
   version "3.0.3"
@@ -15564,6 +16507,14 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+https-proxy-agent@^7.0.1:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
@@ -15751,6 +16702,16 @@ import-from@^2.1.0:
   integrity sha1-M1238qev/VOqpHHUuAId7ja387E=
   dependencies:
     resolve-from "^3.0.0"
+
+import-in-the-middle@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz#8a0a1230c9b865c0e12698171646ae1e3fff691d"
+  integrity sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -18538,6 +19499,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -18789,6 +19755,11 @@ long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
+long@^5.0.0, long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
 longest@^2.0.1:
   version "2.0.1"
@@ -20045,6 +21016,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+module-details-from-path@^1.0.3, module-details-from-path@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
+  integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
+
 moment@2.x.x, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
@@ -20092,7 +21068,7 @@ ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -20300,7 +21276,7 @@ node-cron@^2.0.3:
     opencollective-postinstall "^2.0.0"
     tz-offset "0.0.1"
 
-node-domexception@1.0.0:
+node-domexception@1.0.0, node-domexception@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
@@ -20344,6 +21320,15 @@ node-fetch@^2.6.0:
   integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -22754,6 +23739,24 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
+protobufjs@^7.5.5:
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.1.tgz#6320bb08c3be7dcfc6f9193ee03d3a4643f1eb37"
+  integrity sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.2"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.3.2"
+
 proxy-addr@~2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
@@ -24164,6 +25167,14 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+require-in-the-middle@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz#dbde2587f669398626d56b20c868ab87bf01cce4"
+  integrity sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==
+  dependencies:
+    debug "^4.3.5"
+    module-details-from-path "^1.0.3"
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -27196,6 +28207,11 @@ underscore@1.x:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.2.tgz#0c8d6f536d6f378a5af264a72f7bec50feb7cf2f"
   integrity sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==
 
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
+
 undici@^4.9.3:
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/undici/-/undici-4.12.2.tgz#f2fc50ca77a774ed8c0e7067c9361ee18a2f422b"
@@ -27908,6 +28924,11 @@ web-streams-polyfill@4.0.0-beta.1:
   version "4.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz#3b19b9817374b7cee06d374ba7eeb3aeb80e8c95"
   integrity sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 web-streams-polyfill@^3.2.0:
   version "3.2.0"
@@ -28948,6 +29969,11 @@ yaml@^1.7.2:
   dependencies:
     "@babel/runtime" "^7.6.3"
 
+yaml@^2.0.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
+
 yargs-parser@^10.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
@@ -28996,6 +30022,11 @@ yargs-parser@^21.0.0:
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
   integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@15.0.2:
   version "15.0.2"
@@ -29102,6 +30133,19 @@ yargs@^17.0.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yauzl@^2.4.2:
   version "2.10.0"


### PR DESCRIPTION
Adds prom-client metrics collection as the foundation of the observability stack (Approach B2: GMP + Grafana Cloud). All metrics carry a `client` label for per-instance filtering in Grafana.

- New src/server/metrics.ts: custom prom-client registry with Node.js runtime metrics plus HTTP, GraphQL, SMS, and worker metric definitions
- /metrics endpoint in app.ts (gated on METRICS_ENABLED env var)
- HTTP request duration histogram and counter middleware (method/route/status)
- Apollo Server plugin recording GraphQL operation latency and error counts
- withMetrics wrapper applied to the full Graphile Worker task list
- CLIENT_LABEL and METRICS_ENABLED config vars in src/config.js

First part of https://github.com/With-the-Ranks/Spoke/issues/109
