### PR TITLE
fix(campaign-preview): scope collapse/expand toggle to chevron only

### DIFF
--- a/src/server/lib/templates/pages/campaign-preview/index.tsx
+++ b/src/server/lib/templates/pages/campaign-preview/index.tsx
@@ -115,8 +115,10 @@ const InteractionStep: React.FC<InteractionStepProps> = ({
       )}
       {childSteps && (
         <>
-          <i className="bi bi-chevron-down" />
-          <i className="bi bi-chevron-up" />
+          <span className="chevron-toggle">
+            <i className="bi bi-chevron-down" />
+            <i className="bi bi-chevron-up" />
+          </span>
           <ul>
             {childSteps.map((childStep) => (
               <InteractionStep
@@ -247,17 +249,24 @@ export const renderCampaignPreview = (
           li.collapsed ul {
             display: none;
           }
-          li.interaction-step > i.bi-chevron-down {
+          .chevron-toggle {
+            cursor: pointer;
+            display: inline-block;
+          }
+          .chevron-toggle > i.bi-chevron-down {
             display: none;
           }
-          li.collapsed > i.bi-chevron-up {
+          li.collapsed > .chevron-toggle > i.bi-chevron-up {
             display: none;
           }
-          li.collapsed > i.bi-chevron-down {
+          li.collapsed > .chevron-toggle > i.bi-chevron-down {
             display: inline !important;
           }
-          .no-children i.bi {
+          .no-children .chevron-toggle {
             display: none !important;
+          }
+          .interaction-step > p {
+            pointer-events: none;
           }
           .script {
             font-style: italic;
@@ -269,10 +278,10 @@ export const renderCampaignPreview = (
       <body>
         ${campaignPreviewHtml}
       <script>
-        $(".interaction-step.with-children").on('click', function(event){
+        $(".interaction-step.with-children > .chevron-toggle").on('click', function(event){
           event.stopPropagation();
           event.stopImmediatePropagation();
-          $(this).toggleClass("collapsed");
+          $(this).closest(".interaction-step").toggleClass("collapsed");
         });
       </script>
       </body>


### PR DESCRIPTION
## Summary

- Wraps the chevron icons in a `.chevron-toggle` span to give the collapse/expand action an explicit, isolated click target
- Moves the jQuery click handler from the full `li.interaction-step` to `.chevron-toggle`, so clicking script/text content no longer collapses the step
- Adds `cursor: pointer` on `.chevron-toggle` and `pointer-events: none` on `p` elements within interaction steps to reinforce the intent

## Motivation and Context

https://bernieslack.slack.com/archives/C06R1JH9SGP/p1778860223300079?thread_ts=1778853418.481389&cid=C06R1JH9SGP

## Test plan

- [ ] Open the campaign preview page for a campaign with a branching script
- [ ] Verify clicking the chevron icon collapses/expands child steps
- [ ] Verify clicking on script text or question text does **not** collapse/expand the step
- [ ] Verify nested steps collapse/expand independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)