### PR TITLE
feat(message-review): insert script when survey selected

### DIFF
--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/ConversationPreviewModal.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/ConversationPreviewModal.tsx
@@ -7,9 +7,17 @@ import ChevronLeft from "@material-ui/icons/ChevronLeft";
 import ChevronRight from "@material-ui/icons/ChevronRight";
 import CloseIcon from "@material-ui/icons/Close";
 import type { ConversationInfoFragment } from "@spoke/spoke-codegen";
+import {
+  useGetCampaignVariablesLazyQuery,
+  useGetCurrentUserProfileLazyQuery
+} from "@spoke/spoke-codegen";
 import { css, StyleSheet } from "aphrodite";
-import React from "react";
+import React, { useState } from "react";
 
+import {
+  applyScript,
+  customFieldsJsonStringToArray
+} from "../../../../lib/scripts";
 import MessageColumn from "./MessageColumn";
 import SurveyColumn from "./SurveyColumn";
 
@@ -34,23 +42,59 @@ interface ConversationPreviewBodyProps {
 const ConversationPreviewBody: React.FC<ConversationPreviewBodyProps> = ({
   conversation,
   organizationId
-}) => (
-  <div className={css(columnStyles.container)}>
-    <div className={css(columnStyles.column)}>
-      <MessageColumn
-        conversation={conversation}
-        organizationId={organizationId}
-      />
+}) => {
+  const { contact, campaign } = conversation;
+  const [messageText, setMessageText] = useState("");
+
+  const [getCampaignVariables] = useGetCampaignVariablesLazyQuery();
+  const [getCurrentUserProfile] = useGetCurrentUserProfileLazyQuery();
+
+  const setScriptMessageText = async (script: string) => {
+    const customFields = customFieldsJsonStringToArray(contact.customFields);
+
+    const { data: cvData } = await getCampaignVariables({
+      variables: { campaignId: campaign.id }
+    });
+    const campaignVariables = cvData?.campaign?.campaignVariables ?? [];
+
+    const { data: userData } = await getCurrentUserProfile();
+    const texter = userData?.currentUser;
+
+    if (texter) {
+      setMessageText(
+        applyScript({
+          script,
+          contact,
+          customFields,
+          campaignVariables,
+          texter
+        })
+      );
+    }
+  };
+
+  return (
+    <div className={css(columnStyles.container)}>
+      <div className={css(columnStyles.column)}>
+        <MessageColumn
+          conversation={conversation}
+          organizationId={organizationId}
+          messageText={messageText}
+          onMessageTextChange={setMessageText}
+          onScriptSelected={setScriptMessageText}
+        />
+      </div>
+      <div className={css(columnStyles.column)}>
+        <SurveyColumn
+          contact={conversation.contact}
+          campaign={conversation.campaign}
+          organizationId={organizationId}
+          onScriptSelected={setScriptMessageText}
+        />
+      </div>
     </div>
-    <div className={css(columnStyles.column)}>
-      <SurveyColumn
-        contact={conversation.contact}
-        campaign={conversation.campaign}
-        organizationId={organizationId}
-      />
-    </div>
-  </div>
-);
+  );
+};
 
 interface ConversationPreviewModalProps {
   organizationId: string;

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/index.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/MessageColumn/index.tsx
@@ -1,19 +1,11 @@
 import Button from "@material-ui/core/Button";
 import Grid from "@material-ui/core/Grid";
 import type { ConversationInfoFragment } from "@spoke/spoke-codegen";
-import {
-  useGetCampaignVariablesLazyQuery,
-  useGetCurrentUserProfileLazyQuery,
-  useGetMessageReviewContactUpdatesQuery
-} from "@spoke/spoke-codegen";
+import { useGetMessageReviewContactUpdatesQuery } from "@spoke/spoke-codegen";
 import isNil from "lodash/isNil";
 import React, { useCallback, useState } from "react";
 
 import CannedResponseMenu from "../../../../../components/CannedResponseMenu";
-import {
-  applyScript,
-  customFieldsJsonStringToArray
-} from "../../../../../lib/scripts";
 import MessageList from "./MessageList";
 import MessageOptOut from "./MessageOptOut";
 import MessageResponse from "./MessageResponse";
@@ -31,13 +23,21 @@ type ClickButtonHandler = React.MouseEventHandler<HTMLButtonElement>;
 interface Props {
   organizationId: string;
   conversation: ConversationInfoFragment;
+  messageText: string;
+  onMessageTextChange: (text: string) => void;
+  onScriptSelected: (script: string) => void;
 }
 
 const MessageColumn: React.FC<Props> = (props) => {
-  const { organizationId, conversation } = props;
-  const { contact, campaign } = conversation;
+  const {
+    organizationId,
+    conversation,
+    messageText,
+    onMessageTextChange,
+    onScriptSelected
+  } = props;
+  const { contact } = conversation;
 
-  const [messageText, setMessageText] = useState("");
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
   const { data: updatedContactData } = useGetMessageReviewContactUpdatesQuery({
@@ -48,9 +48,6 @@ const MessageColumn: React.FC<Props> = (props) => {
   const messages = updatedContact?.messages ?? contact.messages;
   const isOptedOut = !isNil(updatedContact?.optOut?.cell);
 
-  const [getCampaignVariables] = useGetCampaignVariablesLazyQuery();
-  const [getCurrentUserProfile] = useGetCurrentUserProfileLazyQuery();
-
   const handleOpenCannedResponse: ClickButtonHandler = useCallback(
     (event) => {
       setAnchorEl(event.currentTarget);
@@ -58,37 +55,12 @@ const MessageColumn: React.FC<Props> = (props) => {
     [setAnchorEl]
   );
 
-  const setScriptMessageText = async (script: string) => {
-    const customFields = customFieldsJsonStringToArray(contact.customFields);
-
-    const { data: cvData } = await getCampaignVariables({
-      variables: {
-        campaignId: campaign.id
-      }
-    });
-    const campaignVariables = cvData?.campaign?.campaignVariables ?? [];
-
-    const { data: userData } = await getCurrentUserProfile();
-    const texter = userData?.currentUser;
-
-    if (texter) {
-      const appliedScript = applyScript({
-        script,
-        contact,
-        customFields,
-        campaignVariables,
-        texter
-      });
-      setMessageText(appliedScript);
-    }
-  };
-
   const handleScriptSelected = useCallback(
     (script: string) => {
       setAnchorEl(null);
-      setScriptMessageText(script);
+      onScriptSelected(script);
     },
-    [setAnchorEl]
+    [setAnchorEl, onScriptSelected]
   );
 
   const handleRequestClose = useCallback(() => setAnchorEl(null), [
@@ -104,7 +76,7 @@ const MessageColumn: React.FC<Props> = (props) => {
           <MessageResponse
             value={messageText}
             conversation={conversation}
-            onChange={setMessageText}
+            onChange={onMessageTextChange}
           />
         )}
         <Grid container spacing={2} justify="flex-end">

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.tsx
@@ -6,13 +6,15 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import type {
+  Campaign,
+  CampaignContact,
+  InteractionStep
+} from "@spoke/spoke-codegen";
 import MenuItem from "material-ui/MenuItem";
 import SelectField from "material-ui/SelectField";
 import React, { useEffect, useState } from "react";
 
-import type { Campaign } from "../../../../../api/campaign";
-import type { CampaignContact } from "../../../../../api/campaign-contact";
-import type { InteractionStep } from "../../../../../api/interaction-step";
 import LoadingIndicator from "../../../../../components/LoadingIndicator";
 import type { MutationMap, QueryMap } from "../../../../../network/types";
 import {
@@ -57,36 +59,42 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
 
   useEffect(() => {
     const { interactionSteps } = props.campaign;
-    const newQuestionResponses = interactionSteps.reduce<QuestionResponseMap>(
+    const newQuestionResponses = interactionSteps?.reduce<QuestionResponseMap>(
       (collector, iStep) => {
-        return iStep.questionResponse
-          ? { ...collector, [iStep.id]: iStep.questionResponse.value }
-          : collector;
+        if (!iStep) return collector;
+        const value = iStep.questionResponse?.value;
+        return value ? { ...collector, [iStep.id]: value } : collector;
       },
       {}
     );
-    setQuestionResponses(newQuestionResponses);
+    setQuestionResponses(newQuestionResponses ?? {});
   }, [props.campaign.interactionSteps]);
 
   const getResponsesFrom = (startingStepId: string) => {
     const { interactionSteps } = props.campaign;
-
     const iSteps: (InteractionStep & { children: InteractionStep[] })[] = [];
+
     let currentStep: InteractionStep | null =
-      interactionSteps.find(
-        (iStep) => iStep.questionText && iStep.id === startingStepId
+      interactionSteps?.find(
+        (iStep) => iStep?.questionText && iStep.id === startingStepId
       ) ?? null;
+
     while (currentStep) {
       const currentStepId = currentStep.id;
-      const children = interactionSteps.filter(
-        (iStep) => iStep.parentInteractionId === currentStepId
-      );
+
+      const children = (
+        interactionSteps?.filter(
+          (iStep) => iStep?.parentInteractionId === currentStepId
+        ) ?? []
+      ).filter((iStep): iStep is InteractionStep => iStep !== null);
+
       iSteps.push({ ...currentStep, children });
       const value = questionResponses[currentStep.id];
+
       currentStep = value
         ? // Only show actionable questions
-          children.find(
-            (iStep) => iStep.questionText && iStep.answerOption === value
+          children?.find(
+            (iStep) => iStep?.questionText && iStep.answerOption === value
           ) ?? null
         : null;
     }
@@ -143,7 +151,8 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
           });
         }
       } catch (error) {
-        setRequestError(formatErrorMessage(error.message));
+        const message = error instanceof Error ? error.message : String(error);
+        setRequestError(formatErrorMessage(message));
         setQuestionResponses(initialQuestionResponses);
       } finally {
         setIsMakingRequest(false);
@@ -157,8 +166,8 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
 
   const { interactionSteps } = props.campaign;
 
-  const startingStep = interactionSteps.find(
-    (iStep) => iStep.parentInteractionId === null
+  const startingStep = interactionSteps?.find(
+    (iStep) => iStep?.parentInteractionId === null
   );
 
   // There may not be an interaction step, or it may not define a question

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/ManageSurveyResponses.tsx
@@ -46,11 +46,13 @@ export interface ManageSurveyResponsesProps {
   campaign: Pick<Campaign, "interactionSteps">;
   contact: CampaignContact;
   mutations: Mutations;
+  onScriptSelected?: (script: string) => void;
 }
 
 export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
   props
 ) => {
+  const { onScriptSelected } = props;
   const [isMakingRequest, setIsMakingRequest] = useState(false);
   const [requestError, setRequestError] = useState("");
   const [questionResponses, setQuestionResponses] = useState<
@@ -141,14 +143,24 @@ export const ManageSurveyResponses: React.FC<ManageSurveyResponsesProps> = (
             interactionStepId: iStepId,
             value
           };
+
           const response = await updateQuestionResponses([input], contact.id);
           if (response.errors) throw response.errors;
+
           updatedQuestionResponses =
             updatedQuestionResponses ?? questionResponses;
           setQuestionResponses({
             ...updatedQuestionResponses,
             [iStepId]: value
           });
+
+          if (onScriptSelected) {
+            const matchingChild = affectedSteps[0]?.children.find(
+              (c: any) => c.answerOption === value
+            );
+            const script = (matchingChild as any)?.scriptOptions?.[0];
+            if (script) onScriptSelected(script);
+          }
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -222,13 +234,14 @@ export interface WrapperProps {
   campaign: Campaign;
   contact: CampaignContact;
   mutations: Mutations;
+  onScriptSelected?: (script: string) => void;
   surveyQuestions: {
     campaign: Pick<Campaign, "id" | "interactionSteps">;
   } & ApolloQueryResult<unknown>;
 }
 
 const ManageSurveyResponsesWrapper: React.FC<WrapperProps> = (props) => {
-  const { surveyQuestions, mutations, contact } = props;
+  const { surveyQuestions, mutations, contact, onScriptSelected } = props;
   return (
     <div>
       <h2>Survey Responses</h2>
@@ -241,6 +254,7 @@ const ManageSurveyResponsesWrapper: React.FC<WrapperProps> = (props) => {
           campaign={surveyQuestions.campaign}
           contact={contact}
           mutations={mutations}
+          onScriptSelected={onScriptSelected}
         />
       )}
     </div>
@@ -260,6 +274,7 @@ const queries: QueryMap<WrapperProps> = {
             parentInteractionId
             isDeleted
             answerActions
+            scriptOptions
 
             questionResponse(campaignContactId: $contactId) {
               id

--- a/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
+++ b/src/containers/AdminIncomingMessageList/components/IncomingMessageList/SurveyColumn/index.tsx
@@ -24,10 +24,11 @@ interface Props {
   organizationId: string;
   campaign: any;
   contact: any;
+  onScriptSelected?: (script: string) => void;
 }
 
 const SurveyColumn: React.FC<Props> = (props) => {
-  const { campaign, contact, organizationId } = props;
+  const { campaign, contact, organizationId, onScriptSelected } = props;
 
   const [isWorking, setIsWorking] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
@@ -67,7 +68,11 @@ const SurveyColumn: React.FC<Props> = (props) => {
   return (
     <div style={styles.container}>
       <ShowTags tags={formattedTags} />
-      <ManageSurveyResponses contact={contact} campaign={campaign} />
+      <ManageSurveyResponses
+        contact={contact}
+        campaign={campaign}
+        onScriptSelected={onScriptSelected}
+      />
       <div style={styles.spacer} />
       <div style={{ display: "flex" }}>
         <div style={styles.spacer} />


### PR DESCRIPTION
## Description

This PR allows the script associated with a survey response to be inserted in the message text box, when a survey is selected in message review

## Motivation and Context

https://bernieslack.slack.com/archives/C06R1JH9SGP/p1778860370877679?thread_ts=1778853418.481389&cid=C06R1JH9SGP

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
