### PR TITLE
feat(nav): show group badges

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -235,6 +235,9 @@ const Navigation: React.FC<Props> = (props) => {
     if (active) setOpenGroup(active.name);
   }, [location.pathname]);
 
+  const getGroupBadgeCount = (group: NavigationGroup) =>
+    group.items.reduce((sum, item) => sum + (item.badge?.count ?? 0), 0);
+
   const renderSection = (section: NavigationSection, indented = false) => {
     const active = isActive(section);
     const IconComponent = navigationIconMap[section.path];
@@ -314,6 +317,7 @@ const Navigation: React.FC<Props> = (props) => {
             groups.map((group) => {
               const groupActive = isGroupActive(group);
               const isOpen = openGroup === group.name;
+              const groupBadgeCount = getGroupBadgeCount(group);
 
               return (
                 <div key={group.name}>
@@ -329,6 +333,13 @@ const Navigation: React.FC<Props> = (props) => {
                       primary={group.name}
                       className={classes.groupHeaderText}
                     />
+                    {!isOpen && groupBadgeCount > 0 && (
+                      <Avatar
+                        className={clsx(classes.badge, classes.actionableBadge)}
+                      >
+                        {groupBadgeCount}
+                      </Avatar>
+                    )}
                     <ExpandMoreIcon
                       fontSize="small"
                       className={clsx(classes.expandIcon, {


### PR DESCRIPTION
## Description

This displays a badge on the group heading for each nav group when the group is collapsed. See screenshots section for a clearer visual explanation

## Motivation and Context

Follow up to #147 to indicate items that need attention when sections are collapsed

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<table>
  <thead>
    <tr>
      <th>Collapsed</th>
      <th>Expanded</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="828" height="1577" alt="image" src="https://github.com/user-attachments/assets/1bdfd836-0ec7-4b4b-bf07-1022428debcd" /></td>
      <td><img width="771" height="1391" alt="image" src="https://github.com/user-attachments/assets/988dddd5-96f3-4a7f-bd85-db26e3446846" />
</td>
    </tr>
  </tbody>
</table>







## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
