### PR TITLE
fix(chat): rearrange Live Support chat position

### DIFF
--- a/src/containers/UserMenu/index.tsx
+++ b/src/containers/UserMenu/index.tsx
@@ -66,6 +66,8 @@ const UserMenu: React.FC<Props> = (props) => {
       history.push(`/superadmin/people`);
     } else if (value === "docs") {
       window.open("https://withtheranks.com/docs/spoke/", "_blank");
+    } else if (value === "liveSupport") {
+      window.$chatwoot?.toggle("open");
     }
   };
 
@@ -137,6 +139,14 @@ const UserMenu: React.FC<Props> = (props) => {
             <OpenInNewIcon />
           </ListItemSecondaryAction>
         </MenuItem>
+        {window.CHATWOOT_WEBSITE_TOKEN && window.CHATWOOT_BASE_URL && (
+          <MenuItem
+            {...dataTest("liveSupport")}
+            onClick={onNavigateFactory("liveSupport")}
+          >
+            Live Support
+          </MenuItem>
+        )}
         <Divider />
         <MenuItem
           {...dataTest("userMenuLogOut")}

--- a/src/server/middleware/app-renderer.js
+++ b/src/server/middleware/app-renderer.js
@@ -55,10 +55,10 @@ const chatwootScript =
   config.CHATWOOT_WEBSITE_TOKEN && chatwootBase
     ? `
     <script>
+      window.chatwootSettings = { hideMessageBubble: true };
       (function (d, t) {
         var BASE_URL = ${JSON.stringify(chatwootBase)};
         var TOKEN = ${JSON.stringify(config.CHATWOOT_WEBSITE_TOKEN)};
-        window.chatwootSettings = { hideMessageBubble: false };
         var g = d.createElement(t),
           s = d.getElementsByTagName(t)[0];
         g.src = BASE_URL + "/packs/js/sdk.js";

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -106,20 +106,12 @@ const layouts: LayoutStyles = {
   }
 };
 
-/** Extra bottom inset when Chatwoot launcher is enabled (window vars from app shell). */
-const chatwootFabBottomOffset =
-  typeof window !== "undefined" &&
-  window.CHATWOOT_WEBSITE_TOKEN &&
-  window.CHATWOOT_BASE_URL
-    ? 80
-    : 0;
-
 const components: ComponentStyles = {
   floatingButton: {
     margin: 0,
     top: "auto",
     right: 20,
-    bottom: 20 + chatwootFabBottomOffset,
+    bottom: 20,
     left: "auto",
     position: "fixed"
   },


### PR DESCRIPTION
## Description

Hides the bottom right chat floating launcher bubble and opens support chat from the profile menu instead.

## Motivation and Context

Currently, chat bubble overlapped texter UI while clicking around. Putting the launcher in the sidebar keeps support available for admins/org owners without covering the main app.


## How Has This Been Tested?

Tested locally.

## Screenshots (if appropriate):
<img width="277" height="482" alt="Screenshot 2026-05-29 at 17 23 20" src="https://github.com/user-attachments/assets/d317cddb-c3d9-4df5-a39a-691c8d549a3c" />

## Documentation Changes

N/A

## Checklist:

N/A
