### PR TITLE
feat: drop bad bens env var

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -156,10 +156,6 @@ const validators = {
     example: "spoke/exports/",
     default: ""
   }),
-  BAD_BENS_DISABLE_HAS_UNASSIGNED_CONTACTS: bool({
-    dec: "Disable use of has unassigned contacts variable",
-    default: false
-  }),
   BASE_URL: url({
     desc:
       "The base URL of the website, without trailing slash, used to construct various URLs.",

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -605,13 +605,8 @@ export const resolvers = {
         .first();
       return row?.contacts_filename ?? null;
     },
-    hasUnassignedContacts: async (campaign) => {
-      if (config.BAD_BENS_DISABLE_HAS_UNASSIGNED_CONTACTS) return false;
-      return checkCampaignContactsExist(
-        campaign,
-        buildHasUnassignedContactsSubquery
-      );
-    },
+    hasUnassignedContacts: async (campaign) =>
+      checkCampaignContactsExist(campaign, buildHasUnassignedContactsSubquery),
     hasUnsentInitialMessages: async (campaign) =>
       checkCampaignContactsExist(campaign, buildHasUnsentInitialsSubquery),
     hasUnhandledMessages: async (campaign) =>


### PR DESCRIPTION
## Description

This drops the env var BAD_BENS_DISABLE_HAS_UNASSIGNED_CONTACTS

## Motivation and Context

Not sure anyone knows what this does anymore so might as well drop it!

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
