### PR TITLE
chore(docker-compose): update for easier onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ JOBS_SAME_PROCESS=1
 PASSPORT_STRATEGY=local
 
 # Database (Postgres)
-DATABASE_URL=postgres://127.0.0.1:5432/spokedev
+DATABASE_URL=postgres://spoke:spoke@localhost:15432/spokedev
 DB_USE_SSL=false
 DB_MIN_POOL=2
 DB_MAX_POOL=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   postgres:
     image: postgres:15


### PR DESCRIPTION
## Description

This PR:
1. Updates `.env.example DATABASE_URL` to point to the docker compose default
2. Removes the deprecated `version` argument from docker compose

## Motivation and Context

Easier onboarding

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
