### PR TITLE
fix(update-dump): handle asdf environment

### DIFF
--- a/update-dump.sh
+++ b/update-dump.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# If yarn isn't usable (not in PATH, or asdf shim broken in non-interactive shell),
+# resolve node/yarn from asdf install paths using the script owner's home directory
+# so this works correctly even when run via sudo.
+if ! yarn --version &>/dev/null; then
+  _owner=$(stat -c '%U' "${BASH_SOURCE[0]}")
+  _owner_home=$(getent passwd "$_owner" | cut -d: -f6)
+  ASDF_INSTALLS="${ASDF_DATA_DIR:-$_owner_home/.asdf}/installs"
+  while IFS=' ' read -r _tool _ver; do
+    [[ "$_tool" == "nodejs" ]] && export PATH="$ASDF_INSTALLS/nodejs/$_ver/bin:$PATH"
+    [[ "$_tool" == "yarn"   ]] && export PATH="$ASDF_INSTALLS/yarn/$_ver/bin:$PATH"
+  done < "$SCRIPT_DIR/.tool-versions"
+fi
+
 PG_HOST_PORT=${1:-"6432"}
 SPOKE_DB="spoke"
 


### PR DESCRIPTION
## Description

This modifies `update-dump.sh` to work with the recommended asdf setup + sudo permissions (at least for me - should be verified on another computer)

## Motivation and Context

Discovered when setting up new computer

## How Has This Been Tested?

This has been tested locally (but should be verified on another computer

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
