### PR TITLE
docs(claude): add note about schema dump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Spoke is a full-stack SMS texting platform for political campaigns and advocacy 
 - Core entities: organizations, campaigns, users, messages, contacts
 - Background job tables managed by Graphile Worker
 - Supports read replicas via `DATABASE_READER_URL`
+- Current state of schema is stored in `schema-dump.sql` - run update-dump.sh to update after introducing new migrations
 
 ### Configuration System
 


### PR DESCRIPTION
## Description

This adds a mention of `schema-dump.sql` to `CLAUDE.md`

## Motivation and Context

Noticed claude trying to repeatedly read a ton of migrations instead of the dump locally

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at http://docs.spokerewired.com/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
