### PR TITLE
feat(dialer): add GraphQL schema, resolvers, and Telnyx token route 

### DIFF
--- a/libs/gql-schema/dialer.ts
+++ b/libs/gql-schema/dialer.ts
@@ -1,0 +1,49 @@
+export const schema = `
+  type DialerCampaignContact {
+    id: ID!
+    campaignId: ID!
+    firstName: String!
+    lastName: String!
+    zip: String
+    callStatus: String!
+    doNotCall: Boolean!
+    attemptCount: Int!
+    lastAttemptedAt: Date
+    customFields: JSON!
+    assignment: Assignment
+    interactionSteps: [InteractionStep!]!
+    questionResponseValues: [DialerQuestionResponseValue!]!
+    tags: [Tag!]!
+  }
+
+  type DialerQuestionResponseValue {
+    id: ID!
+    interactionStepId: ID!
+    question: String!
+    value: String!
+  }
+
+  type DialerCall {
+    id: ID!
+    dialerCampaignContactId: ID!
+    status: String!
+    fromNumber: String
+    disposition: String
+    telnyxCallControlId: String
+    createdAt: Date!
+    endedAt: Date
+  }
+
+  type InitiateCallResult {
+    dialerCallId: ID!
+    contactPhone: String!
+    fromNumber: String!
+  }
+
+  input DialerQuestionResponseInput {
+    interactionStepId: String!
+    value: String!
+  }
+`;
+
+export default schema;

--- a/libs/gql-schema/schema.ts
+++ b/libs/gql-schema/schema.ts
@@ -7,6 +7,7 @@ import { schema as campaignGroupSchema } from "./campaign-group";
 import { schema as campaignVariableSchema } from "./campaign-variable";
 import { schema as cannedResponseSchema } from "./canned-response";
 import { schema as conversationSchema } from "./conversations";
+import { schema as dialerSchema } from "./dialer";
 import { schema as externalActivistCodeSchema } from "./external-activist-code";
 import { schema as externalListSchema } from "./external-list";
 import { schema as externalResultCodeSchema } from "./external-result-code";
@@ -246,6 +247,8 @@ const rootSchema = `
   type RootQuery {
     currentUser: User
     organization(id:String!, utc:String): Organization
+    getNextDialerContact(assignmentId: String!): DialerCampaignContact
+    getDialerContact(dialerCampaignContactId: String!): DialerCampaignContact
     campaign(id:String!): Campaign
     inviteByHash(hash:String!): [Invite]
     contact(id:String!): CampaignContact
@@ -281,6 +284,10 @@ const rootSchema = `
 
   type RootMutation {
     createInvite(invite:InviteInput!): Invite
+    initiateCall(assignmentId: String!, dialerCampaignContactId: String!): InitiateCallResult!
+    updateDialerCall(dialerCallId: String!, status: String, disposition: String, telnyxCallControlId: String): DialerCall!
+    saveDialerQuestionResponses(dialerCampaignContactId: String!, questionResponses: [DialerQuestionResponseInput!]!): DialerCampaignContact!
+    markDialerContactComplete(dialerCampaignContactId: String!, callStatus: String!): DialerCampaignContact!
     createCampaign(campaign:CampaignInput!): Campaign
     createTemplateCampaign(organizationId: String!): Campaign!
     deleteTemplateCampaign(organizationId: String!, campaignId: String!): Boolean!
@@ -425,7 +432,8 @@ export const schema = [
   externalResponseOptionSchema,
   externalActivistCodeSchema,
   externalResultCodeSchema,
-  externalSyncConfigSchema
+  externalSyncConfigSchema,
+  dialerSchema
 ];
 
 export default rootSchema;

--- a/libs/spoke-codegen/src/graphql/dialer.graphql
+++ b/libs/spoke-codegen/src/graphql/dialer.graphql
@@ -1,0 +1,115 @@
+fragment DialerContactCore on DialerCampaignContact {
+  id
+  campaignId
+  firstName
+  lastName
+  zip
+  callStatus
+  doNotCall
+  attemptCount
+  lastAttemptedAt
+  customFields
+  questionResponseValues {
+    id
+    interactionStepId
+    question
+    value
+  }
+  tags {
+    id
+    title
+    description
+    confirmationSteps
+    onApplyScript
+    textColor
+    backgroundColor
+    isAssignable
+    isSystem
+  }
+  interactionSteps {
+    id
+    questionText
+    scriptOptions
+    answerOption
+    parentInteractionId
+    isDeleted
+    answerActions
+    question {
+      text
+      answerOptions {
+        value
+        nextInteractionStep {
+          id
+          scriptOptions
+        }
+      }
+    }
+  }
+}
+
+query GetNextDialerContact($assignmentId: String!) {
+  getNextDialerContact(assignmentId: $assignmentId) {
+    ...DialerContactCore
+  }
+}
+
+query GetDialerContact($dialerCampaignContactId: String!) {
+  getDialerContact(dialerCampaignContactId: $dialerCampaignContactId) {
+    ...DialerContactCore
+  }
+}
+
+mutation InitiateCall($assignmentId: String!, $dialerCampaignContactId: String!) {
+  initiateCall(assignmentId: $assignmentId, dialerCampaignContactId: $dialerCampaignContactId) {
+    dialerCallId
+    contactPhone
+    fromNumber
+  }
+}
+
+mutation UpdateDialerCall(
+  $dialerCallId: String!
+  $status: String
+  $disposition: String
+  $telnyxCallControlId: String
+) {
+  updateDialerCall(
+    dialerCallId: $dialerCallId
+    status: $status
+    disposition: $disposition
+    telnyxCallControlId: $telnyxCallControlId
+  ) {
+    id
+    status
+    disposition
+    telnyxCallControlId
+    endedAt
+  }
+}
+
+mutation SaveDialerQuestionResponses(
+  $dialerCampaignContactId: String!
+  $questionResponses: [DialerQuestionResponseInput!]!
+) {
+  saveDialerQuestionResponses(
+    dialerCampaignContactId: $dialerCampaignContactId
+    questionResponses: $questionResponses
+  ) {
+    ...DialerContactCore
+  }
+}
+
+mutation MarkDialerContactComplete(
+  $dialerCampaignContactId: String!
+  $callStatus: String!
+) {
+  markDialerContactComplete(
+    dialerCampaignContactId: $dialerCampaignContactId
+    callStatus: $callStatus
+  ) {
+    id
+    callStatus
+    attemptCount
+    lastAttemptedAt
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -762,6 +762,21 @@ const validators = {
     desc: "Custom base URL for Switchboard client.",
     default: undefined
   }),
+  TELNYX_API_KEY: str({
+    desc:
+      "Telnyx API key (secret) used server-side to mint short-lived WebRTC access tokens. Never sent to the browser.",
+    default: undefined
+  }),
+  TELNYX_TELEPHONY_CREDENTIAL_ID: str({
+    desc:
+      "ID of a Telnyx telephony credential (tied to a SIP connection) that WebRTC access tokens are minted from.",
+    default: undefined
+  }),
+  TELNYX_DEFAULT_FROM_NUMBER: str({
+    desc:
+      "Caller ID number (E.164) used for dialer calls when not sourcing numbers from a messaging service (e.g. local/fakeservice testing). Must be a number owned by your Telnyx account.",
+    default: undefined
+  }),
   VAN_BASE_URL: url({
     desc:
       "The base url to use when interacting with VAN (may need to change for international use)",

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -212,6 +212,8 @@ type OptOutByCampaign {
 type RootQuery {
   currentUser: User
   organization(id:String!, utc:String): Organization
+  getNextDialerContact(assignmentId: String!): DialerCampaignContact
+  getDialerContact(dialerCampaignContactId: String!): DialerCampaignContact
   campaign(id:String!): Campaign
   inviteByHash(hash:String!): [Invite]
   contact(id:String!): CampaignContact
@@ -247,6 +249,10 @@ input SecondPassInput {
 
 type RootMutation {
   createInvite(invite:InviteInput!): Invite
+  initiateCall(assignmentId: String!, dialerCampaignContactId: String!): InitiateCallResult!
+  updateDialerCall(dialerCallId: String!, status: String, disposition: String, telnyxCallControlId: String): DialerCall!
+  saveDialerQuestionResponses(dialerCampaignContactId: String!, questionResponses: [DialerQuestionResponseInput!]!): DialerCampaignContact!
+  markDialerContactComplete(dialerCampaignContactId: String!, callStatus: String!): DialerCampaignContact!
   createCampaign(campaign:CampaignInput!): Campaign
   createTemplateCampaign(organizationId: String!): Campaign!
   deleteTemplateCampaign(organizationId: String!, campaignId: String!): Boolean!
@@ -1473,4 +1479,52 @@ type ExternalSyncTagConfigEdge {
 type ExternalSyncTagConfigPage {
   edges: [ExternalSyncTagConfigEdge!]!
   pageInfo: RelayPageInfo!
+}
+
+
+
+type DialerCampaignContact {
+  id: ID!
+  campaignId: ID!
+  firstName: String!
+  lastName: String!
+  zip: String
+  callStatus: String!
+  doNotCall: Boolean!
+  attemptCount: Int!
+  lastAttemptedAt: Date
+  customFields: JSON!
+  assignment: Assignment
+  interactionSteps: [InteractionStep!]!
+  questionResponseValues: [DialerQuestionResponseValue!]!
+  tags: [Tag!]!
+}
+
+type DialerQuestionResponseValue {
+  id: ID!
+  interactionStepId: ID!
+  question: String!
+  value: String!
+}
+
+type DialerCall {
+  id: ID!
+  dialerCampaignContactId: ID!
+  status: String!
+  fromNumber: String
+  disposition: String
+  telnyxCallControlId: String
+  createdAt: Date!
+  endedAt: Date
+}
+
+type InitiateCallResult {
+  dialerCallId: ID!
+  contactPhone: String!
+  fromNumber: String!
+}
+
+input DialerQuestionResponseInput {
+  interactionStepId: String!
+  value: String!
 }

--- a/src/server/api/dialer.ts
+++ b/src/server/api/dialer.ts
@@ -9,10 +9,10 @@ export const resolvers = {
     firstName: (c: DialerContactRecord) => c.first_name,
     lastName: (c: DialerContactRecord) => c.last_name,
     zip: (c: DialerContactRecord) => c.zip,
-    callStatus: (c: DialerContactRecord) => c.call_status,
+    callStatus: (c: DialerContactWithData) => c.callStatus,
     doNotCall: (c: DialerContactRecord) => c.do_not_call,
-    attemptCount: (c: DialerContactRecord) => c.attempt_count,
-    lastAttemptedAt: (c: DialerContactRecord) => c.last_attempted_at,
+    attemptCount: (c: DialerContactWithData) => c.attemptCount,
+    lastAttemptedAt: (c: DialerContactWithData) => c.lastAttemptedAt,
     customFields: (c: DialerContactRecord) => c.custom_fields,
     assignment: (
       c: DialerContactRecord,
@@ -35,7 +35,6 @@ export const resolvers = {
       c.dialer_campaign_contact_id,
     status: (c: DialerCallRecord) => c.status,
     fromNumber: (c: DialerCallRecord) => c.from_number,
-    disposition: (c: DialerCallRecord) => c.disposition,
     telnyxCallControlId: (c: DialerCallRecord) => c.telnyx_call_control_id,
     createdAt: (c: DialerCallRecord) => c.created_at,
     endedAt: (c: DialerCallRecord) => c.ended_at

--- a/src/server/api/dialer.ts
+++ b/src/server/api/dialer.ts
@@ -1,0 +1,45 @@
+import { r } from "../models";
+import type { DialerContactWithData } from "./lib/dialer";
+import type { DialerCallRecord, DialerContactRecord } from "./types";
+
+export const resolvers = {
+  DialerCampaignContact: {
+    id: (c: DialerContactRecord) => c.id,
+    campaignId: (c: DialerContactRecord) => c.campaign_id,
+    firstName: (c: DialerContactRecord) => c.first_name,
+    lastName: (c: DialerContactRecord) => c.last_name,
+    zip: (c: DialerContactRecord) => c.zip,
+    callStatus: (c: DialerContactRecord) => c.call_status,
+    doNotCall: (c: DialerContactRecord) => c.do_not_call,
+    attemptCount: (c: DialerContactRecord) => c.attempt_count,
+    lastAttemptedAt: (c: DialerContactRecord) => c.last_attempted_at,
+    customFields: (c: DialerContactRecord) => c.custom_fields,
+    assignment: (
+      c: DialerContactRecord,
+      _args: unknown,
+      { loaders }: { loaders: any }
+    ) => (c.assignment_id ? loaders.assignment.load(c.assignment_id) : null),
+    interactionSteps: (c: DialerContactWithData) =>
+      c.interactionSteps ??
+      r
+        .reader("interaction_step")
+        .where({ campaign_id: c.campaign_id, is_deleted: false }),
+    questionResponseValues: (c: DialerContactWithData) =>
+      c.questionResponseValues ?? [],
+    tags: (c: DialerContactWithData) => c.tags ?? []
+  },
+
+  DialerCall: {
+    id: (c: DialerCallRecord) => c.id,
+    dialerCampaignContactId: (c: DialerCallRecord) =>
+      c.dialer_campaign_contact_id,
+    status: (c: DialerCallRecord) => c.status,
+    fromNumber: (c: DialerCallRecord) => c.from_number,
+    disposition: (c: DialerCallRecord) => c.disposition,
+    telnyxCallControlId: (c: DialerCallRecord) => c.telnyx_call_control_id,
+    createdAt: (c: DialerCallRecord) => c.created_at,
+    endedAt: (c: DialerCallRecord) => c.ended_at
+  }
+};
+
+export default resolvers;

--- a/src/server/api/lib/dialer.ts
+++ b/src/server/api/lib/dialer.ts
@@ -10,7 +10,19 @@ import type {
 import { getNumberForDial } from "./assemble-numbers";
 import { getMessagingServiceById } from "./message-sending";
 
+const ACTIVE_OR_FINAL_STATUSES = [
+  "QUEUED",
+  "DIALING",
+  "IN_PROGRESS",
+  "COMPLETED",
+  "VOICEMAIL",
+  "ERROR"
+];
+
 export interface DialerContactWithData extends DialerContactRecord {
+  callStatus: string;
+  attemptCount: number;
+  lastAttemptedAt: Date | null;
   interactionSteps: unknown[];
   questionResponseValues: unknown[];
   tags: unknown[];
@@ -19,7 +31,7 @@ export interface DialerContactWithData extends DialerContactRecord {
 export const getContactWithData = async (
   contact: DialerContactRecord
 ): Promise<DialerContactWithData> => {
-  const [questionResponses, tags, interactionSteps] = await Promise.all([
+  const [questionResponses, tags, interactionSteps, calls] = await Promise.all([
     r
       .reader("dialer_question_response")
       .join(
@@ -46,11 +58,18 @@ export const getContactWithData = async (
       .select("tag.*"),
     r
       .reader("interaction_step")
-      .where({ campaign_id: contact.campaign_id, is_deleted: false })
+      .where({ campaign_id: contact.campaign_id, is_deleted: false }),
+    r
+      .reader("dialer_call")
+      .where({ dialer_campaign_contact_id: contact.id })
+      .orderBy("created_at", "desc")
   ]);
 
   return {
     ...contact,
+    callStatus: calls[0]?.status ?? "NOT_ATTEMPTED",
+    attemptCount: calls.length,
+    lastAttemptedAt: calls[0]?.created_at ?? null,
     interactionSteps,
     tags,
     questionResponseValues: questionResponses.map((qr) => ({
@@ -98,7 +117,14 @@ export const getNextDialerContact = async (
       do_not_call: false,
       archived: false
     })
-    .whereIn("call_status", ["not_attempted", "no_answer"])
+    .whereNotExists(function (this: any) {
+      this.select(r.reader.raw(1))
+        .from("dialer_call")
+        .whereRaw(
+          "dialer_call.dialer_campaign_contact_id = dialer_campaign_contact.id"
+        )
+        .whereIn("dialer_call.status", ACTIVE_OR_FINAL_STATUSES);
+    })
     .orderBy("id", "asc")
     .first();
 
@@ -166,6 +192,17 @@ export const initiateCall = async (
     fromNumber = dialResult.fromNumber;
   }
 
+  // Guard against double-clicks: bail if an active call already exists.
+  const activeCall = await r
+    .knex("dialer_call")
+    .where({ dialer_campaign_contact_id: contact.id })
+    .whereIn("status", ["QUEUED", "DIALING", "IN_PROGRESS"])
+    .first("id");
+
+  if (activeCall) {
+    throw new UserInputError("This contact is already being called.");
+  }
+
   const [dialerCall] = (await r
     .knex("dialer_call")
     .insert({
@@ -176,11 +213,6 @@ export const initiateCall = async (
       created_at: new Date()
     })
     .returning("*")) as DialerCallRecord[];
-
-  await r
-    .knex("dialer_campaign_contact")
-    .where({ id: contact.id })
-    .update({ call_status: "in_progress" });
 
   return {
     dialerCallId: dialerCall.id,
@@ -194,7 +226,6 @@ export const updateDialerCall = async (
   user: Pick<UserRecord, "id" | "is_superadmin">,
   updates: {
     status?: string;
-    disposition?: string;
     telnyxCallControlId?: string;
   }
 ): Promise<DialerCallRecord> => {
@@ -210,8 +241,6 @@ export const updateDialerCall = async (
 
   const patch: Record<string, unknown> = {};
   if (updates.status !== undefined) patch.status = updates.status;
-  if (updates.disposition !== undefined)
-    patch.disposition = updates.disposition;
   if (updates.telnyxCallControlId !== undefined)
     patch.telnyx_call_control_id = updates.telnyxCallControlId;
 
@@ -264,15 +293,12 @@ export const markDialerContactComplete = async (
 ): Promise<DialerContactWithData> => {
   const contact = await assertContactAccess(dialerCampaignContactId, user);
 
-  const [updated] = (await r
-    .knex("dialer_campaign_contact")
-    .where({ id: contact.id })
-    .update({
-      call_status: callStatus,
-      attempt_count: r.knex.raw("attempt_count + 1"),
-      last_attempted_at: new Date()
-    })
-    .returning("*")) as DialerContactRecord[];
+  if (callStatus === "do_not_call") {
+    await r
+      .knex("dialer_campaign_contact")
+      .where({ id: contact.id })
+      .update({ do_not_call: true });
+  }
 
-  return getContactWithData(updated);
+  return getContactWithData(contact);
 };

--- a/src/server/api/lib/dialer.ts
+++ b/src/server/api/lib/dialer.ts
@@ -1,0 +1,278 @@
+import { ForbiddenError, UserInputError } from "apollo-server-errors";
+
+import { config } from "../../../config";
+import { r } from "../../models";
+import type {
+  DialerCallRecord,
+  DialerContactRecord,
+  UserRecord
+} from "../types";
+import { getNumberForDial } from "./assemble-numbers";
+import { getMessagingServiceById } from "./message-sending";
+
+export interface DialerContactWithData extends DialerContactRecord {
+  interactionSteps: unknown[];
+  questionResponseValues: unknown[];
+  tags: unknown[];
+}
+
+export const getContactWithData = async (
+  contact: DialerContactRecord
+): Promise<DialerContactWithData> => {
+  const [questionResponses, tags, interactionSteps] = await Promise.all([
+    r
+      .reader("dialer_question_response")
+      .join(
+        "interaction_step as istep",
+        "dialer_question_response.interaction_step_id",
+        "istep.id"
+      )
+      .where({
+        "dialer_question_response.dialer_campaign_contact_id": contact.id,
+        "dialer_question_response.is_deleted": false
+      })
+      .select(
+        "dialer_question_response.id",
+        "dialer_question_response.interaction_step_id",
+        "dialer_question_response.value",
+        "istep.question as istep_question"
+      ),
+    r
+      .reader("dialer_campaign_contact_tag")
+      .join("tag", "tag.id", "dialer_campaign_contact_tag.tag_id")
+      .where({
+        "dialer_campaign_contact_tag.dialer_campaign_contact_id": contact.id
+      })
+      .select("tag.*"),
+    r
+      .reader("interaction_step")
+      .where({ campaign_id: contact.campaign_id, is_deleted: false })
+  ]);
+
+  return {
+    ...contact,
+    interactionSteps,
+    tags,
+    questionResponseValues: questionResponses.map((qr) => ({
+      id: qr.id,
+      interactionStepId: qr.interaction_step_id,
+      question: qr.istep_question,
+      value: qr.value
+    }))
+  };
+};
+
+const assertContactAccess = async (
+  dialerCampaignContactId: string,
+  user: Pick<UserRecord, "id" | "is_superadmin">
+): Promise<DialerContactRecord> => {
+  const contact: DialerContactRecord | undefined = await r
+    .knex("dialer_campaign_contact")
+    .where({ id: dialerCampaignContactId })
+    .first();
+
+  if (!contact) throw new UserInputError("Dialer contact not found.");
+
+  if (!user.is_superadmin && contact.assignment_id) {
+    const assignment = await r
+      .reader("assignment")
+      .where({ id: contact.assignment_id, user_id: user.id })
+      .first();
+    if (!assignment) {
+      throw new ForbiddenError(
+        "You are not authorized to access that contact."
+      );
+    }
+  }
+
+  return contact;
+};
+
+export const getNextDialerContact = async (
+  assignmentId: string
+): Promise<DialerContactWithData | null> => {
+  const contact: DialerContactRecord | undefined = await r
+    .reader("dialer_campaign_contact")
+    .where({
+      assignment_id: assignmentId,
+      do_not_call: false,
+      archived: false
+    })
+    .whereIn("call_status", ["not_attempted", "no_answer"])
+    .orderBy("id", "asc")
+    .first();
+
+  if (!contact) return null;
+  return getContactWithData(contact);
+};
+
+export const getDialerContact = async (
+  dialerCampaignContactId: string,
+  user: Pick<UserRecord, "id" | "is_superadmin">
+): Promise<DialerContactWithData> => {
+  const contact = await assertContactAccess(dialerCampaignContactId, user);
+  return getContactWithData(contact);
+};
+
+export const initiateCall = async (
+  assignmentId: string,
+  dialerCampaignContactId: string,
+  user: Pick<UserRecord, "id" | "is_superadmin">
+): Promise<{
+  dialerCallId: number;
+  contactPhone: string;
+  fromNumber: string;
+}> => {
+  const contact: DialerContactRecord | undefined = await r
+    .knex("dialer_campaign_contact")
+    .where({ id: dialerCampaignContactId, assignment_id: assignmentId })
+    .first();
+
+  if (!contact) throw new UserInputError("Contact not found.");
+  if (contact.do_not_call)
+    throw new UserInputError("Contact is on the do-not-call list.");
+
+  let fromNumber: string;
+
+  if (config.DEFAULT_SERVICE === "fakeservice") {
+    // Local/fakeservice testing doesn't have a messaging service to source
+    // numbers from, so use a configured Telnyx-owned caller ID instead.
+    if (!config.TELNYX_DEFAULT_FROM_NUMBER) {
+      throw new Error(
+        "TELNYX_DEFAULT_FROM_NUMBER must be set to place dialer calls in fakeservice mode."
+      );
+    }
+    fromNumber = config.TELNYX_DEFAULT_FROM_NUMBER;
+  } else {
+    const campaign = await r
+      .reader("all_campaign")
+      .where({ id: contact.campaign_id })
+      .first();
+
+    if (!campaign?.messaging_service_sid) {
+      throw new Error("No messaging service configured for this campaign.");
+    }
+
+    const messagingService = await getMessagingServiceById(
+      campaign.messaging_service_sid
+    );
+
+    const dialResult = await getNumberForDial(
+      messagingService,
+      contact.cell,
+      contact.zip ?? undefined
+    );
+
+    fromNumber = dialResult.fromNumber;
+  }
+
+  const [dialerCall] = (await r
+    .knex("dialer_call")
+    .insert({
+      dialer_campaign_contact_id: contact.id,
+      user_id: user.id,
+      from_number: fromNumber,
+      status: "QUEUED",
+      created_at: new Date()
+    })
+    .returning("*")) as DialerCallRecord[];
+
+  await r
+    .knex("dialer_campaign_contact")
+    .where({ id: contact.id })
+    .update({ call_status: "in_progress" });
+
+  return {
+    dialerCallId: dialerCall.id,
+    contactPhone: contact.cell,
+    fromNumber
+  };
+};
+
+export const updateDialerCall = async (
+  dialerCallId: string,
+  user: Pick<UserRecord, "id" | "is_superadmin">,
+  updates: {
+    status?: string;
+    disposition?: string;
+    telnyxCallControlId?: string;
+  }
+): Promise<DialerCallRecord> => {
+  const existingCall: DialerCallRecord | undefined = await r
+    .knex("dialer_call")
+    .where({ id: dialerCallId })
+    .first();
+
+  if (!existingCall) throw new UserInputError("Dialer call not found.");
+  if (!user.is_superadmin && existingCall.user_id !== user.id) {
+    throw new ForbiddenError("You are not authorized to update this call.");
+  }
+
+  const patch: Record<string, unknown> = {};
+  if (updates.status !== undefined) patch.status = updates.status;
+  if (updates.disposition !== undefined)
+    patch.disposition = updates.disposition;
+  if (updates.telnyxCallControlId !== undefined)
+    patch.telnyx_call_control_id = updates.telnyxCallControlId;
+
+  const terminalStatuses = ["COMPLETED", "NO_ANSWER", "VOICEMAIL", "ERROR"];
+  if (updates.status && terminalStatuses.includes(updates.status)) {
+    patch.ended_at = new Date();
+  }
+
+  const [updated] = (await r
+    .knex("dialer_call")
+    .where({ id: dialerCallId })
+    .update(patch)
+    .returning("*")) as DialerCallRecord[];
+
+  return updated;
+};
+
+export const saveDialerQuestionResponses = async (
+  dialerCampaignContactId: string,
+  questionResponses: Array<{ interactionStepId: string; value: string }>,
+  user: Pick<UserRecord, "id" | "is_superadmin">
+): Promise<DialerContactWithData> => {
+  const contact = await assertContactAccess(dialerCampaignContactId, user);
+
+  for (const qr of questionResponses) {
+    await r
+      .knex("dialer_question_response")
+      .insert({
+        dialer_campaign_contact_id: contact.id,
+        interaction_step_id: qr.interactionStepId,
+        value: qr.value,
+        created_at: new Date(),
+        updated_at: new Date()
+      })
+      .onConflict(
+        r.knex.raw(
+          "(interaction_step_id, dialer_campaign_contact_id) WHERE is_deleted = false"
+        ) as any
+      )
+      .merge({ value: qr.value, updated_at: new Date() });
+  }
+
+  return getContactWithData(contact);
+};
+
+export const markDialerContactComplete = async (
+  dialerCampaignContactId: string,
+  callStatus: string,
+  user: Pick<UserRecord, "id" | "is_superadmin">
+): Promise<DialerContactWithData> => {
+  const contact = await assertContactAccess(dialerCampaignContactId, user);
+
+  const [updated] = (await r
+    .knex("dialer_campaign_contact")
+    .where({ id: contact.id })
+    .update({
+      call_status: callStatus,
+      attempt_count: r.knex.raw("attempt_count + 1"),
+      last_attempted_at: new Date()
+    })
+    .returning("*")) as DialerContactRecord[];
+
+  return getContactWithData(updated);
+};

--- a/src/server/api/root-mutations.ts
+++ b/src/server/api/root-mutations.ts
@@ -62,6 +62,12 @@ import {
   markAutosendingPaused,
   unqueueAutosending
 } from "./lib/campaign";
+import {
+  initiateCall,
+  markDialerContactComplete,
+  saveDialerQuestionResponses,
+  updateDialerCall
+} from "./lib/dialer";
 import { getSecondPassCampaign } from "./lib/mark-second-pass";
 import { saveNewIncomingMessage } from "./lib/message-sending";
 import { processNumbers } from "./lib/opt-out";
@@ -3331,6 +3337,73 @@ const rootMutations = {
       });
 
       return true;
+    },
+
+    initiateCall: async (
+      _root,
+      {
+        assignmentId,
+        dialerCampaignContactId
+      }: { assignmentId: string; dialerCampaignContactId: string },
+      { user }: SpokeRequestContext
+    ) => {
+      await assignmentRequired(user, assignmentId);
+      return initiateCall(assignmentId, dialerCampaignContactId, user);
+    },
+
+    updateDialerCall: async (
+      _root,
+      {
+        dialerCallId,
+        status,
+        disposition,
+        telnyxCallControlId
+      }: {
+        dialerCallId: string;
+        status?: string;
+        disposition?: string;
+        telnyxCallControlId?: string;
+      },
+      { user }: SpokeRequestContext
+    ) => {
+      return updateDialerCall(dialerCallId, user, {
+        status,
+        disposition,
+        telnyxCallControlId
+      });
+    },
+
+    saveDialerQuestionResponses: async (
+      _root,
+      {
+        dialerCampaignContactId,
+        questionResponses
+      }: {
+        dialerCampaignContactId: string;
+        questionResponses: Array<{ interactionStepId: string; value: string }>;
+      },
+      { user }: SpokeRequestContext
+    ) => {
+      return saveDialerQuestionResponses(
+        dialerCampaignContactId,
+        questionResponses,
+        user
+      );
+    },
+
+    markDialerContactComplete: async (
+      _root,
+      {
+        dialerCampaignContactId,
+        callStatus
+      }: { dialerCampaignContactId: string; callStatus: string },
+      { user }: SpokeRequestContext
+    ) => {
+      return markDialerContactComplete(
+        dialerCampaignContactId,
+        callStatus,
+        user
+      );
     }
   }
 };

--- a/src/server/api/root-mutations.ts
+++ b/src/server/api/root-mutations.ts
@@ -3356,19 +3356,16 @@ const rootMutations = {
       {
         dialerCallId,
         status,
-        disposition,
         telnyxCallControlId
       }: {
         dialerCallId: string;
         status?: string;
-        disposition?: string;
         telnyxCallControlId?: string;
       },
       { user }: SpokeRequestContext
     ) => {
       return updateDialerCall(dialerCallId, user, {
         status,
-        disposition,
         telnyxCallControlId
       });
     },

--- a/src/server/api/root-resolvers.ts
+++ b/src/server/api/root-resolvers.ts
@@ -12,8 +12,14 @@ import { r } from "../models";
 import { getCampaigns } from "./campaign";
 import { queryCampaignOverlaps } from "./campaign-overlap";
 import { getConversations } from "./conversations";
-import { accessRequired, authRequired, superAdminRequired } from "./errors";
+import {
+  accessRequired,
+  assignmentRequired,
+  authRequired,
+  superAdminRequired
+} from "./errors";
 import { getStepsToUpdate } from "./lib/bulk-script-editor";
+import { getDialerContact, getNextDialerContact } from "./lib/dialer";
 import { formatPage } from "./lib/pagination";
 import { getUsers, getUsersById } from "./user";
 
@@ -524,6 +530,19 @@ const rootResolvers = {
         };
       });
     },
+    getNextDialerContact: async (_root, { assignmentId }, { user }) => {
+      await assignmentRequired(user, assignmentId);
+      return getNextDialerContact(assignmentId);
+    },
+
+    getDialerContact: async (
+      _root,
+      { dialerCampaignContactId }: { dialerCampaignContactId: string },
+      { user }
+    ) => {
+      return getDialerContact(dialerCampaignContactId, user);
+    },
+
     isValidAttachment: async (_root, { fileUrl }, _context) => {
       // 2025-03-25: @npcz/magic is throwing an uncatachable exception
       // skip file type validation for now

--- a/src/server/api/schema.ts
+++ b/src/server/api/schema.ts
@@ -11,6 +11,7 @@ import { resolvers as campaignGroupResolvers } from "./campaign-group";
 import { resolvers as campaignVariableResolvers } from "./campaign-variable";
 import { resolvers as cannedResponseResolvers } from "./canned-response";
 import { resolvers as conversationsResolver } from "./conversations";
+import { resolvers as dialerResolvers } from "./dialer";
 import { resolvers as externalActivistCodeResolvers } from "./external-activist-code";
 import { resolvers as externalListResolvers } from "./external-list";
 import { resolvers as externalResultCodeResolvers } from "./external-result-code";
@@ -76,6 +77,7 @@ export const resolvers = {
   ...{ Upload: GraphQLUpload },
   ...questionResolvers,
   ...conversationsResolver,
+  ...dialerResolvers,
   ...rootMutations
 };
 

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -325,6 +325,38 @@ export interface TagRecord {
   deleted_at: string;
 }
 
+export interface DialerContactRecord {
+  id: number;
+  campaign_id: number;
+  assignment_id: number | null;
+  external_id: string | null;
+  first_name: string;
+  last_name: string;
+  cell: string;
+  zip: string | null;
+  timezone: string | null;
+  custom_fields: Record<string, unknown>;
+  call_status: string;
+  do_not_call: boolean;
+  attempt_count: number;
+  last_attempted_at: Date | null;
+  archived: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface DialerCallRecord {
+  id: number;
+  dialer_campaign_contact_id: number;
+  user_id: number;
+  telnyx_call_control_id: string | null;
+  from_number: string | null;
+  status: string;
+  disposition: string | null;
+  created_at: Date;
+  ended_at: Date | null;
+}
+
 export interface UserRecord {
   id: number;
   auth0_id: string;

--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -336,10 +336,7 @@ export interface DialerContactRecord {
   zip: string | null;
   timezone: string | null;
   custom_fields: Record<string, unknown>;
-  call_status: string;
   do_not_call: boolean;
-  attempt_count: number;
-  last_attempted_at: Date | null;
   archived: boolean;
   created_at: Date;
   updated_at: Date;
@@ -352,7 +349,6 @@ export interface DialerCallRecord {
   telnyx_call_control_id: string | null;
   from_number: string | null;
   status: string;
-  disposition: string | null;
   created_at: Date;
   ended_at: Date | null;
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -24,6 +24,7 @@ import {
   nexmoRouter,
   previewRouter,
   settingsRouter,
+  telnyxRouter,
   twilioRouter,
   utilsRouter
 } from "./routes";
@@ -135,6 +136,7 @@ export const createApp = async () => {
   app.use(nexmoRouter);
   app.use(twilioRouter);
   app.use(assembleRouter);
+  app.use(telnyxRouter);
   app.use(utilsRouter);
   app.use(previewRouter);
   app.use(settingsRouter);

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -4,6 +4,7 @@ import previewRouter from "./campaign-preview";
 import { createRouter as createGraphqlRouter } from "./graphql";
 import nexmoRouter from "./nexmo";
 import settingsRouter from "./settings";
+import telnyxRouter from "./telnyx";
 import twilioRouter from "./twilio";
 import utilsRouter from "./utils";
 
@@ -14,6 +15,7 @@ export {
   twilioRouter,
   assembleRouter,
   settingsRouter,
+  telnyxRouter,
   utilsRouter,
   previewRouter
 };

--- a/src/server/routes/telnyx.ts
+++ b/src/server/routes/telnyx.ts
@@ -1,0 +1,94 @@
+import express from "express";
+import superagent from "superagent";
+
+import { config } from "../../config";
+import logger from "../../logger";
+import { r } from "../models";
+import type { SpokeRequest } from "../types";
+import { errToObj } from "../utils";
+
+const router = express.Router();
+
+// Mints a short-lived Telnyx WebRTC access token (JWT) for the logged-in user.
+// The Telnyx API key and SIP credentials never leave the server; the browser
+// only ever receives an ephemeral, scoped token to log in to TelnyxRTC.
+router.get("/telnyx/token", async (req, res) => {
+  const spokeReq = req as SpokeRequest;
+  if (!spokeReq.user) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { TELNYX_API_KEY, TELNYX_TELEPHONY_CREDENTIAL_ID } = config;
+  if (!TELNYX_API_KEY || !TELNYX_TELEPHONY_CREDENTIAL_ID) {
+    return res
+      .status(503)
+      .json({ error: "Telnyx calling is not configured on this server." });
+  }
+
+  try {
+    const response = await superagent
+      .post(
+        `https://api.telnyx.com/v2/telephony_credentials/${TELNYX_TELEPHONY_CREDENTIAL_ID}/token`
+      )
+      .set("Authorization", `Bearer ${TELNYX_API_KEY}`);
+
+    // The token endpoint returns the JWT as a plain-text body.
+    const loginToken = response.text?.trim();
+    if (!loginToken) {
+      throw new Error("Telnyx returned an empty access token");
+    }
+
+    return res.json({ login_token: loginToken });
+  } catch (err: any) {
+    logger.error("Error minting Telnyx access token", { ...errToObj(err) });
+    return res
+      .status(502)
+      .json({ error: "Could not obtain a Telnyx access token." });
+  }
+});
+
+// Telnyx Call Control webhook — updates dialer_call rows as call state changes
+router.post("/telnyx/call-control", async (req, res) => {
+  const { data } = req.body ?? {};
+  if (!data) return res.status(400).json({ error: "Missing event data" });
+
+  const { event_type, payload } = data;
+  const callControlId: string | undefined = payload?.call_control_id;
+  if (!callControlId) return res.status(200).send();
+
+  try {
+    const statusMap: Record<string, string> = {
+      "call.initiated": "DIALING",
+      "call.answered": "IN_PROGRESS",
+      "call.hangup": "COMPLETED"
+    };
+
+    const newStatus = statusMap[event_type];
+    if (!newStatus) return res.status(200).send();
+
+    const updates: Record<string, unknown> = {
+      telnyx_call_control_id: callControlId,
+      status: newStatus
+    };
+
+    if (newStatus === "COMPLETED") {
+      updates.ended_at = new Date();
+    }
+
+    await r
+      .knex("dialer_call")
+      .where({ telnyx_call_control_id: callControlId })
+      .update(updates);
+
+    return res.status(200).send();
+  } catch (err: any) {
+    logger.error("Error handling Telnyx call-control webhook", {
+      ...errToObj(err),
+      event_type,
+      callControlId
+    });
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
- DialerCampaignContact, DialerCall, InitiateCallResult GQL types
- getNextDialerContact / getDialerContact queries
- initiateCall (calls getNumberForDial for local presence), updateDialerCall, saveDialerQuestionResponses, markDialerContactComplete mutations
- /telnyx/token endpoint (serves SIP credentials to authenticated volunteers)
- /telnyx/call-control webhook handler (updates dialer_call on call state events)
- TELNYX_API_KEY / TELNYX_TELEPHONY_CREDENTIAL_ID / TELNYX_DEFAULT_FROM_NUMBER config vars
- Codegen graphql file with typed React hooks for all dialer operations

