### PR TITLE
chore: extract contact table type

### DIFF
--- a/src/server/api/types.ts
+++ b/src/server/api/types.ts
@@ -98,6 +98,8 @@ export interface CampaignContactRecord {
   archived: boolean;
 }
 
+export type ContactTable = "campaign_contact" | "dialer_campaign_contact";
+
 export interface CampaignRecord {
   id: number;
   organization_id: number;

--- a/src/server/tasks/assign-texters.ts
+++ b/src/server/tasks/assign-texters.ts
@@ -1,8 +1,8 @@
+import type { TexterAssignmentInput } from "@spoke/spoke-codegen";
 import type { Pool, PoolClient } from "pg";
 
-import type { TexterAssignmentInput } from "../../api/assignment";
 import { DateTime } from "../../lib/datetime";
-import type { CampaignRecord } from "../api/types";
+import type { CampaignRecord, ContactTable } from "../api/types";
 import { Notifications, sendUserNotification } from "../notifications";
 import { withTransaction } from "../utils";
 import type { ProgressTask } from "./utils";
@@ -21,7 +21,7 @@ export interface AssignmentTarget {
 // ordering baked into the per-stage option defaults). Only call campaigns
 // override the table and assignable rules.
 interface ContactTableConfig {
-  table?: string;
+  table?: ContactTable;
   // Extra SQL predicate (with a leading "and ") restricting which unassigned
   // contacts may be handed out.
   assignableFilter?: string;
@@ -87,7 +87,7 @@ export const ensureAssignments = async (options: EnsureAssignmentsOptions) => {
 
 interface ZeroOutDeletedOptions {
   client: PoolClient | Pool;
-  table?: string;
+  table?: ContactTable;
   campaignId: number;
   isArchived: boolean;
   assignmentIds: number[];
@@ -120,7 +120,7 @@ export const zeroOutDeleted = async (options: ZeroOutDeletedOptions) => {
 
 interface FreeUpTextersOptions {
   client: PoolClient;
-  table?: string;
+  table?: ContactTable;
   campaignId: number;
   isArchived: boolean;
   assignmentTargets: AssignmentTarget[];
@@ -173,7 +173,7 @@ export const freeUpTexters = async (options: FreeUpTextersOptions) => {
 
 interface AssignPayloadsOptions {
   client: PoolClient;
-  table?: string;
+  table?: ContactTable;
   assignableFilter?: string;
   assignableOrder?: string;
   campaignId: number;


### PR DESCRIPTION
## Description

This adds a `ContactTable` type (including `campaign_contact | dialer_campaign_contact`)
## Motivation and Context

Follow up to #207 and want to reuse this type for dialer VAN sync

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
