### PR TITLE
ci: add release notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,18 @@ jobs:
           prerelease: ${{ !!steps.semver_parser.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Notify Slack
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          VERSION: ${{ steps.semver_parser.outputs.fullversion }}
+          RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/v${{ steps.semver_parser.outputs.fullversion }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL secret not set, skipping Slack notification"
+            exit 0
+          fi
+          jq -n \
+            --arg text "New Spoke release: <$RELEASE_URL|v$VERSION>" \
+            '{text: $text}' \
+          | curl -X POST -H "Content-Type: application/json" -d @- "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Description

This adds a CI step to post a Slack notification linking the new Spoke version after a release is created

## Motivation and Context

Automated coordination btwn Spoke devs and rest of team

## How Has This Been Tested?

https://withtheranks.slack.com/archives/C0694QK8A3X/p1785202565174779

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
