### PR TITLE
fix(teams): remove team restriction when no teams for campaign

### DIFF
--- a/src/containers/AdminCampaignEdit/sections/CampaignTeamsForm.jsx
+++ b/src/containers/AdminCampaignEdit/sections/CampaignTeamsForm.jsx
@@ -31,7 +31,11 @@ class CampaignTeamsForm extends React.Component {
   };
 
   handleChange = (_event, value) => {
-    this.props.onChange({ teams: value });
+    const update = { teams: value };
+    if (value.length === 0) {
+      update.isAssignmentLimitedToTeams = false;
+    }
+    this.props.onChange(update);
   };
 
   render() {


### PR DESCRIPTION
## Description

This resets the  "Restrict assignment solely to members of these teams?" toggle when no teams are selected on the campaign builder page

## Motivation and Context

Noticed on check in call this morning

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
