### PR TITLE
perf(message-sending): fetch contact fields with messaging service

### DIFF
--- a/src/server/api/lib/assemble-numbers.ts
+++ b/src/server/api/lib/assemble-numbers.ts
@@ -178,12 +178,7 @@ export const sendMessage = async (
   );
   const profileId = service.messaging_service_sid;
   const numbers = await numbersClient(service);
-
-  const { zip: contactZipCode, send_after: sendAfter } = await r
-    .reader("campaign_contact")
-    .join("campaign", "campaign_contact.campaign_id", "campaign.id")
-    .where({ "campaign_contact.id": campaignContactId })
-    .first("campaign_contact.zip as zip", "campaign.send_after as send_after");
+  const { zip: contactZipCode, send_after: sendAfter } = service;
 
   const { features } = await r
     .reader("organization")

--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -121,7 +121,8 @@ export const getMessagingServiceById = async (messagingServiceId) =>
  * Fetches an existing assigned messaging service for a campaign contact. If no messaging service
  * has been assigned then assign one and return that.
  * @param {number} campaignContactId The ID of the target campaign contact
- * @returns {object} Assigned messaging service Postgres row
+ * @returns {object} Assigned messaging service Postgres row, merged with the contact's
+ * `zip` and the campaign's `send_after`
  */
 export const getContactMessagingService = async (
   campaignContactId,
@@ -139,10 +140,22 @@ export const getContactMessagingService = async (
       "campaign_contact.campaign_id"
     )
     .where({ "campaign_contact.id": campaignContactId })
-    .first();
+    .first("messaging_service_sid", "send_after", "zip", "cell");
+
+  const contactFields = {
+    zip: campaignData.zip,
+    send_after: campaignData.send_after
+  };
 
   if (campaignData.messaging_service_sid) {
-    return getMessagingServiceById(campaignData.messaging_service_sid);
+    const messagingService = await getMessagingServiceById(
+      campaignData.messaging_service_sid
+    );
+
+    return {
+      ...messagingService,
+      ...contactFields
+    };
   }
 
   const {
@@ -160,21 +173,16 @@ export const getContactMessagingService = async (
     existingMessagingService &&
     existingMessagingService.messaging_service_sid
   ) {
-    return existingMessagingService;
+    return { ...existingMessagingService, ...contactFields };
   }
-
-  const campaignContact = await r
-    .reader("campaign_contact")
-    .where({ id: campaignContactId })
-    .first("cell");
 
   // Otherwise select an appropriate messaging service and assign
   const assignedService = await assignMessagingServiceSID(
-    campaignContact.cell,
+    campaignData.cell,
     parseInt(organizationId, 10)
   );
 
-  return assignedService;
+  return { ...assignedService, ...contactFields };
 };
 
 /**


### PR DESCRIPTION
## Description

This moves the fetching of `campaign_contact` columns needed for switchboard sending into the general `message-sending` flow to avoid an extra query

## Motivation and Context

Considering we always use switchboard in prod, we might as well fetch these columns across the board and skip doing an extra query

## How Has This Been Tested?

N/A 

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
