### PR TITLE
fix(template-campaigns): show alert when copied

### DIFF
--- a/src/containers/AdminTemplateCampaigns/components/TemplateCampaignRow.tsx
+++ b/src/containers/AdminTemplateCampaigns/components/TemplateCampaignRow.tsx
@@ -13,17 +13,20 @@ import IconButton from "@material-ui/core/IconButton";
 import ListItemIcon from "@material-ui/core/ListItemIcon";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
+import Snackbar from "@material-ui/core/Snackbar";
 import { makeStyles } from "@material-ui/core/styles";
 import AddIcon from "@material-ui/icons/AddOutlined";
 import DeleteIcon from "@material-ui/icons/DeleteOutlined";
 import EditIcon from "@material-ui/icons/Edit";
 import FileCopyIcon from "@material-ui/icons/FileCopyOutlined";
 import MoreVertIcon from "@material-ui/icons/MoreVertOutlined";
+import Alert from "@material-ui/lab/Alert";
 import type { TemplateCampaignFragment } from "@spoke/spoke-codegen";
 import isEmpty from "lodash/isEmpty";
 import type { ReactNode } from "react";
 import React, { useCallback, useState } from "react";
 
+import type { CreateCampaignFromTemplateDialogProps } from "../../../components/CreateCampaignFromTemplateDialog";
 import CreateCampaignFromTemplateDialog from "../../../components/CreateCampaignFromTemplateDialog";
 import { DateTime } from "../../../lib/datetime";
 
@@ -57,6 +60,7 @@ export const TemplateCampaignRow: React.FC<TemplateCampaignRowProps> = ({
     false
   );
   const [menuAnchor, setMenuAnchor] = useState<HTMLButtonElement | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string>("");
 
   const classes = useStyles();
 
@@ -119,6 +123,19 @@ export const TemplateCampaignRow: React.FC<TemplateCampaignRowProps> = ({
   const handleCreateTemplateClicked = () => {
     setCreateFromTemplateOpen(true);
   };
+
+  const handleCreateTemplateCompleted: CreateCampaignFromTemplateDialogProps["onCreateTemplateCompleted"] = (
+    copiedCampaigns,
+    selectedTemplateTitle
+  ) => {
+    const campaignLabel =
+      copiedCampaigns.length === 1 ? "campaign" : "campaigns";
+    setSuccessMessage(
+      `Created ${copiedCampaigns.length} ${campaignLabel} from "${selectedTemplateTitle}"`
+    );
+  };
+
+  const handleCloseSuccessMessage = () => setSuccessMessage("");
 
   return (
     <Card>
@@ -209,7 +226,17 @@ export const TemplateCampaignRow: React.FC<TemplateCampaignRowProps> = ({
         open={createFromTemplateOpen}
         defaultTemplate={templateCampaign}
         onClose={() => setCreateFromTemplateOpen(false)}
+        onCreateTemplateCompleted={handleCreateTemplateCompleted}
       />
+      <Snackbar
+        open={successMessage !== ""}
+        autoHideDuration={4000}
+        onClose={handleCloseSuccessMessage}
+      >
+        <Alert onClose={handleCloseSuccessMessage} severity="success">
+          {successMessage}
+        </Alert>
+      </Snackbar>
     </Card>
   );
 };


### PR DESCRIPTION
## Description

This adds an alert to show success after copying from a template campaign

## Motivation and Context

Having no feedback made it hard to know if the copy operation succeeded or not

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<img width="1524" height="1054" alt="image" src="https://github.com/user-attachments/assets/fced8970-a372-4ed8-9f8a-0f1280818f42" />

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
