### PR TITLE
fix(graphql): use date scalar type for timestamps

### DIFF
--- a/libs/gql-schema/campaign-group.ts
+++ b/libs/gql-schema/campaign-group.ts
@@ -11,8 +11,8 @@ export const schema = `
     name: String!
     description: String!
     campaigns: CampaignPage!
-    createdAt: String!
-    updatedAt: String!
+    createdAt: Date!
+    updatedAt: Date!
   }
 
   type CampaignGroupEdge {

--- a/libs/gql-schema/campaign.ts
+++ b/libs/gql-schema/campaign.ts
@@ -112,7 +112,7 @@ export const schema = `
     repliesStaleAfter: Int
     isAssignmentLimitedToTeams: Boolean!
     timezone: String
-    createdAt: String!
+    createdAt: Date!
     previewUrl: String
     landlinesFiltered: Boolean!
     externalSystem: ExternalSystem

--- a/libs/gql-schema/messaging-service.ts
+++ b/libs/gql-schema/messaging-service.ts
@@ -8,7 +8,7 @@ export const schema = `
     id: ID!
     messagingServiceSid: String!
     serviceType: MessagingServiceType!
-    updatedAt: String!
+    updatedAt: Date!
     name: String
     active: Boolean!
     isDefault: Boolean

--- a/libs/gql-schema/organization.ts
+++ b/libs/gql-schema/organization.ts
@@ -56,7 +56,7 @@ export const schema = `
     messagingServices(after: Cursor, first: Int, active: Boolean): MessagingServicePage
     campaignGroups(after: Cursor, first: Int): CampaignGroupPage!
     templateCampaigns(after: Cursor, first: Int): CampaignPage!
-    deletedAt: String
+    deletedAt: Date
     deletedBy: User
     autosendingMps: Int
   }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -445,7 +445,7 @@ type Organization {
   messagingServices(after: Cursor, first: Int, active: Boolean): MessagingServicePage
   campaignGroups(after: Cursor, first: Int): CampaignGroupPage!
   templateCampaigns(after: Cursor, first: Int): CampaignPage!
-  deletedAt: String
+  deletedAt: Date
   deletedBy: User
   autosendingMps: Int
 }
@@ -679,7 +679,7 @@ type Campaign {
   repliesStaleAfter: Int
   isAssignmentLimitedToTeams: Boolean!
   timezone: String
-  createdAt: String!
+  createdAt: Date!
   previewUrl: String
   landlinesFiltered: Boolean!
   externalSystem: ExternalSystem
@@ -848,7 +848,7 @@ type MessagingService {
   id: ID!
   messagingServiceSid: String!
   serviceType: MessagingServiceType!
-  updatedAt: String!
+  updatedAt: Date!
   name: String
   active: Boolean!
   isDefault: Boolean
@@ -959,8 +959,8 @@ type CampaignGroup {
   name: String!
   description: String!
   campaigns: CampaignPage!
-  createdAt: String!
-  updatedAt: String!
+  createdAt: Date!
+  updatedAt: Date!
 }
 
 type CampaignGroupEdge {


### PR DESCRIPTION
## Description

This converts a few `String` timestamps scattered in the codebase to the custom `Date` GraphQL scalar type

## Motivation and Context

Noticed bug with displaying template campaign creation date as shown in the screenshot here https://github.com/With-the-Ranks/Spoke/pull/224 The other timestamps affected by this PR aren't displayed to users

The `Date` scalar ensures the timestamps are returned as ISO strings, which is how they're generally worked with throughout the codebase. The serialization code for the type (from `node_modules`) :

```
serialize: function (value) {
  assertErr(value instanceof Date, TypeError, ...)
  return value.toJSON()   // -> proper ISO 8601 string, e.g. "2026-07-30T12:34:56.789Z"
}
```

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
