### PR TITLE
feat(campaign-stats): conditionally show autosending button

### DIFF
--- a/libs/spoke-codegen/src/graphql/campaign-stats.graphql
+++ b/libs/spoke-codegen/src/graphql/campaign-stats.graphql
@@ -32,6 +32,20 @@ query getCampaign($campaignId: String!) {
       name
       id
     }
+    readiness {
+      id
+      basics
+      messagingService
+      textingHours
+      integration
+      contacts
+      autoassign
+      cannedResponses
+      campaignGroups
+      campaignVariables
+      interactions
+      texters
+    }
   }
 }
 

--- a/src/containers/AdminAutosending/index.tsx
+++ b/src/containers/AdminAutosending/index.tsx
@@ -60,6 +60,7 @@ const AdminAutosending: React.FC = () => {
     error: getCampaignsError
   } = useCampaignsEligibleForAutosendingQuery({
     variables: { organizationId, isStarted, isBasic },
+    fetchPolicy: "cache-and-network",
     pollInterval: 10 * 1000
   });
 

--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -10,7 +10,8 @@ import Alert from "@material-ui/lab/Alert";
 import {
   GetCampaignDocument,
   GetOrganizationDataDocument,
-  GetOrganizationsDocument
+  GetOrganizationsDocument,
+  StartCampaignDocument
 } from "@spoke/spoke-codegen";
 import { css, StyleSheet } from "aphrodite";
 import PropTypes from "prop-types";
@@ -94,7 +95,9 @@ class AdminCampaignStats extends React.Component {
     copyCampaignError: undefined,
     exportCampaignOpen: false,
     exportCampaignError: undefined,
-    moreMenuAnchor: null
+    moreMenuAnchor: null,
+    startCampaignErrorOpen: false,
+    startCampaignError: undefined
   };
 
   handleNavigateToEdit = () => {
@@ -106,6 +109,20 @@ class AdminCampaignStats extends React.Component {
   handleNavigateToAutosending = () => {
     const { organizationId } = this.props.match.params;
     this.props.history.push(`/admin/${organizationId}/autosending`);
+  };
+
+  handleStartCampaign = async () => {
+    try {
+      const result = await this.props.mutations.startCampaign();
+      if (result.errors) {
+        throw result.errors;
+      }
+    } catch (error) {
+      this.setState({
+        startCampaignError: error.message ?? String(error),
+        startCampaignErrorOpen: true
+      });
+    }
   };
 
   handleOpenMoreMenu = (event) => {
@@ -239,7 +256,11 @@ class AdminCampaignStats extends React.Component {
     if (!campaign) {
       return <h1> Uh oh! Campaign {campaignId} doesn't seem to exist </h1>;
     }
-    const { pendingJobs, messagingService } = campaign;
+    const { pendingJobs, messagingService, readiness } = campaign;
+
+    const isCampaignReady = Object.keys(readiness)
+      .filter((key) => key !== "__typename" && key !== "id")
+      .every((key) => readiness[key]);
 
     const currentExportJob = pendingJobs.find(
       (job) => job.jobType === "export"
@@ -336,12 +357,19 @@ class AdminCampaignStats extends React.Component {
                 >
                   Edit
                 </Button>
-                <Button
-                  variant="outlined"
-                  onClick={this.handleNavigateToAutosending}
-                >
-                  Autosending
-                </Button>
+                {!campaign.isStarted && isCampaignReady && (
+                  <Button variant="outlined" onClick={this.handleStartCampaign}>
+                    Start Campaign
+                  </Button>
+                )}
+                {campaign.isStarted && window.ENABLE_AUTOSENDING && (
+                  <Button
+                    variant="outlined"
+                    onClick={this.handleNavigateToAutosending}
+                  >
+                    Autosending
+                  </Button>
+                )}
                 {isAdmin && (
                   <>
                     <Button
@@ -474,6 +502,18 @@ class AdminCampaignStats extends React.Component {
           }}
         />
         <Snackbar
+          open={this.state.startCampaignErrorOpen}
+          autoHideDuration={5000}
+          onClose={() => {
+            this.setState({
+              startCampaignErrorOpen: false,
+              startCampaignError: undefined
+            });
+          }}
+        >
+          <Alert severity="error">{this.state.startCampaignError}</Alert>
+        </Snackbar>
+        <Snackbar
           open={this.state.campaignJustCopied}
           message={
             this.state.copyCampaignError
@@ -567,6 +607,10 @@ const queries = {
 };
 
 const mutations = {
+  startCampaign: (ownProps) => () => ({
+    mutation: StartCampaignDocument,
+    variables: { campaignId: ownProps.match.params.campaignId }
+  }),
   archiveCampaign: (ownProps) => () => ({
     mutation: gql`
       mutation archiveCampaign($campaignId: String!) {


### PR DESCRIPTION
## Description

This refactors the buttons on the campaign stats page in the following way:
1. If a campaign isn't ready to start, only the Edit button appears (so the admin can go to the edit page and fill in details
2. If a campaign is ready to start, a "Start campaign" button appears. When clicked, it's replaced by the Autosending button (if autosending is enabled
3. If a campaign is started (and autosending is enabled), show the Autosending button

A few related bug fixes are also added here:
1. Checking for the `ENABLE_AUTOSENDING` variable before showing the Autosending button
2. Fetching autosending campaigns using `cache-and-network` policy, so that clicking "Start campaign" followed by "Autosending" allows admins to immediately begin autosending the newly started campaign, rather than having to refresh the page 

## Motivation and Context

Admins reported confusion about clicking the autosending button for the campaign and not seeing it show up because the campaign was unstarted

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
