### PR TITLE
feat(copy-campaign): link new campaign in notification

### DIFF
--- a/src/containers/AdminCampaignStats/index.jsx
+++ b/src/containers/AdminCampaignStats/index.jsx
@@ -16,7 +16,7 @@ import { css, StyleSheet } from "aphrodite";
 import PropTypes from "prop-types";
 import React from "react";
 import { Helmet } from "react-helmet";
-import { withRouter } from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 import { compose } from "recompose";
 
 import CampaignNavigation from "../../components/CampaignNavigation";
@@ -476,9 +476,19 @@ class AdminCampaignStats extends React.Component {
         <Snackbar
           open={this.state.campaignJustCopied}
           message={
-            this.state.copyCampaignError
-              ? `Error: ${this.state.copyCampaignError}`
-              : `Campaign successfully copied to campaign ${this.state.copiedCampaignId}`
+            this.state.copyCampaignError ? (
+              `Error: ${this.state.copyCampaignError}`
+            ) : (
+              <span>
+                Campaign successfully copied to{" "}
+                <Link
+                  to={`/admin/${organizationId}/campaigns/${this.state.copiedCampaignId}/edit`}
+                  style={{ color: theme.colors.white }}
+                >
+                  campaign {this.state.copiedCampaignId}
+                </Link>
+              </span>
+            )
           }
           autoHideDuration={5000}
           onClose={() => {


### PR DESCRIPTION
## Description

This links the newly created campaign in the notification that appears when clicking the Copy Campaign button on the Campaign Stats page

## Motivation and Context

Previously, there was no way to immediately navigate to the newly created campaign

## How Has This Been Tested?

This has been tested locally

## Screenshots (if appropriate):


<img width="730" height="436" alt="image" src="https://github.com/user-attachments/assets/cb047705-91c6-49c7-b5a8-dd61fe32c995" />


## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
