### PR TITLE
perf: prefer campaign contact archived checks over campaign

### DIFF
--- a/src/server/api/lib/send-message.ts
+++ b/src/server/api/lib/send-message.ts
@@ -110,7 +110,6 @@ export const sendMessage = async (
     .join("campaign", "campaign_contact.campaign_id", "campaign.id")
     .where({ "campaign_contact.id": parseInt(campaignContactId, 10) })
     .whereRaw("campaign_contact.archived = false")
-    .where({ "campaign.is_archived": false })
     .leftJoin("assignment", "campaign_contact.assignment_id", "assignment.id");
 
   if (config.ENABLE_MONTHLY_ORG_MESSAGE_LIMITS) {
@@ -133,7 +132,6 @@ export const sendMessage = async (
       "campaign_contact.assignment_id as assignment_id",
       "campaign_contact.message_status as cc_message_status",
       "campaign.id as campaign_id",
-      "campaign.is_archived as is_archived",
       "campaign.organization_id as organization_id",
       "campaign.timezone as c_timezone",
       "campaign.texting_hours_start as c_texting_hours_start",

--- a/src/server/api/root-mutations.ts
+++ b/src/server/api/root-mutations.ts
@@ -1559,10 +1559,9 @@ const rootMutations = {
         const contactUpdates = r
           .knex("campaign_contact")
           .transacting(trx)
-          .leftJoin("campaign", "campaign_contact.campaign_id", "campaign.id")
           .where({
             "campaign_contact.cell": cell,
-            "campaign.is_archived": false
+            "campaign_contact.archived": false
           })
           .pluck("campaign_contact.id")
           .then((contactIdsRes) => {
@@ -2243,10 +2242,9 @@ const rootMutations = {
           set
             assignment_id = null
           from
-            assignment, campaign
+            assignment
           where
             campaign_contact.campaign_id = ?
-            and campaign.id = campaign_contact.campaign_id
             and assignment.id = campaign_contact.assignment_id
             and is_opted_out = false
             and message_status = ?


### PR DESCRIPTION
## Summary
- `campaign_contact.archived` is kept in sync with `campaign.is_archived`, so several queries were doing redundant work by also joining to / filtering on `campaign.is_archived`.
- `sendMessage`: removed the redundant `campaign.is_archived` where-clause (already covered by `campaign_contact.archived = false`) and the unused `is_archived` select alias.
- `removeOptOut`: dropped the `leftJoin` to `campaign` — it existed solely to filter `is_archived`, which `campaign_contact.archived` already gives us directly.
- `releaseMessages`: dropped the unnecessary `campaign` join in the raw `UPDATE ... FROM` clause — the `is_archived` value is already substituted as a literal from a separate lookup, and no other `campaign` column was used.

## Test plan
- [ ] `yarn test` (send-message / root-mutations specs)
- [ ] Manually opt a contact back in via Admin → Incoming Message List (`removeOptOut` path)
- [ ] Manually run "Release Unsent Messages" / "Release Unreplied Conversations" from Admin → Campaign List (`releaseMessages` path)
- [ ] Send a message as a texter (`sendMessage` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)